### PR TITLE
Fix name for puppetlabs/stdlib in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "project_page": "https://github.com/puppet-community/puppetcommunity-extlib",
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
+      "name": "puppetlabs/stdlib",
       "version_range": ">= 3.2.1"
     }
   ]


### PR DESCRIPTION
Dash no good, slash is where it's at. Apparently.
