### PR TITLE
rename puppet[ -]?community -> voxpupuli

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'metadata-json-lint',                                         :require => false
   gem 'rspec-puppet-facts',                                         :require => false
   gem 'rspec',                                                      :require => false
-  gem 'puppet-blacksmith',                                          :require => false, :git => 'https://github.com/puppet-community/puppet-blacksmith.git'
+  gem 'puppet-blacksmith',                                          :require => false, :git => 'https://github.com/voxpupuli/puppet-blacksmith.git'
   gem 'rubocop',                                                    :require => false
   gem 'rspec-puppet-utils',                                         :require => false
   gem 'puppetlabs_spec_helper',                                     :require => false

--- a/README.markdown
+++ b/README.markdown
@@ -1,5 +1,5 @@
 [![Puppet Forge](http://img.shields.io/puppetforge/v/puppet/extlib.svg)](https://forge.puppetlabs.com/puppet/extlib)
-[![Build Status](https://img.shields.io/travis/puppet-community/puppet-extlib/master.svg)](https://travis-ci.org/puppet-community/puppet-extlib)
+[![Build Status](https://img.shields.io/travis/voxpupuli/puppet-extlib/master.svg)](https://travis-ci.org/puppet-community/puppet-extlib)
 
 #### Table of Contents
 

--- a/lib/puppet/parser/functions/resources_deep_merge.rb
+++ b/lib/puppet/parser/functions/resources_deep_merge.rb
@@ -1,17 +1,3 @@
-#  Copyright 2015 Puppet Community
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 Puppet::Parser::Functions.newfunction(:resources_deep_merge, :type => :rvalue, :doc => <<-EOS
 Deeply merge a "defaults" hash into a "resources" hash like the ones expected
 by create_resources(). Internally calls the puppetlabs-stdlib function

--- a/metadata.json
+++ b/metadata.json
@@ -1,12 +1,12 @@
 {
   "name": "puppet-extlib",
   "version": "0.11.1-rc0",
-  "source": "https://github.com/puppet-community/puppetcommunity-extlib",
+  "source": "https://github.com/voxpupuli/puppetcommunity-extlib",
   "author": "puppetcommunity",
   "license": "Apache-2.0",
   "summary": "extlib provides functions out of scope puppetlabs/stdlib",
   "description": "extlib provides functions out of scope puppetlabs/stdlib",
-  "project_page": "https://github.com/puppet-community/puppetcommunity-extlib",
+  "project_page": "https://github.com/voxpupuli/puppetcommunity-extlib",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",

--- a/spec/functions/resources_deep_merge_spec.rb
+++ b/spec/functions/resources_deep_merge_spec.rb
@@ -1,19 +1,5 @@
 #! /usr/bin/env ruby -S rspec
 
-#  Copyright 2015 Puppet Community
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 require 'spec_helper'
 
 describe 'resources_deep_merge' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,3 @@
-#  Copyright 2015 Puppet Community
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
-
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 # From https://gist.github.com/stefanozanella/4190920


### PR DESCRIPTION
ax copyright where it exists, since vox pupuli is not an entity yet