### PR TITLE
Pin rake to avoid rubocop/rake 11 incompatibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,12 +26,18 @@ Metrics/AbcSize:
 Metrics/MethodLength:
   Enabled: false
 
+# Module length is not necessarily an indicator of code quality
+Metrics/ModuleLength:
+  Enabled: false
+
 # Class length is not necessarily an indicator of code quality
 Metrics/ClassLength:
   Enabled: false
 
 # dealbreaker:
 Style/TrailingCommaInArguments:
+  Enabled: false
+Style/TrailingCommaInLiteral:
   Enabled: false
 Style/ClosingParenthesisIndentation:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,4 @@ deploy:
     all_branches: true
     # Only publish if our main Ruby target builds
     rvm: 1.9.3
+    condition: "$FUTURE_PARSER = yes"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ with:
 This will run the tests on an Ubuntu 12.04 virtual machine. You can also
 run the integration tests against Centos 6.5 with.
 
-    RS_SET=centos-64-x64 bundle exec rake acceptances
+    BEAKER_set=centos-64-x64 bundle exec rake acceptances
 
 If you don't want to have to recreate the virtual machine every time you
 can use `BEAKER_DESTROY=no` and `BEAKER_PROVISION=no`. On the first run you will

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
-  gem 'rake',                                                       :require => false
+  gem 'rake', '< 11',                                               :require => false
   gem 'rspec-puppet',                                               :require => false, :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppet-lint',                                                :require => false, :git => 'https://github.com/rodjek/puppet-lint.git'
   gem 'metadata-json-lint',                                         :require => false
@@ -58,7 +58,7 @@ else
 gem 'facter', :require => false, :groups => [:test]
 end
 
-ENV['PUPPET_VERSION'].nil? ? puppetversion = '3.8.4' : puppetversion = ENV['PUPPET_VERSION'].to_s
+ENV['PUPPET_VERSION'].nil? ? puppetversion = '3.8.5' : puppetversion = ENV['PUPPET_VERSION'].to_s
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim:ft=ruby


### PR DESCRIPTION
See https://github.com/voxpupuli/modulesync_config/pull/93

This commit updates the module to our latest modulesync configuration.