### PR TITLE
Move function spec tests

### DIFF
--- a/spec/unit/puppet/parser/functions/cache_data_spec.rb
+++ b/spec/unit/puppet/parser/functions/cache_data_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'cache_data' do
+describe 'cache_data', type: :puppet_function do
   include Mocha::ParameterMatchers
 
   let(:initial_data) { 'my_password' }

--- a/spec/unit/puppet/parser/functions/default_content_spec.rb
+++ b/spec/unit/puppet/parser/functions/default_content_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'default_content' do
+describe 'default_content', type: :puppet_function do
   describe 'signature validation' do
     it 'exists' do
       is_expected.not_to be_nil

--- a/spec/unit/puppet/parser/functions/dump_args_spec.rb
+++ b/spec/unit/puppet/parser/functions/dump_args_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 require 'json'
-describe 'dump_args' do
+describe 'dump_args', type: :puppet_function do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it 'exists' do

--- a/spec/unit/puppet/parser/functions/echo_spec.rb
+++ b/spec/unit/puppet/parser/functions/echo_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'echo' do
+describe 'echo', type: :puppet_function do
   describe 'signature validation' do
     it 'exists' do
       is_expected.not_to be_nil

--- a/spec/unit/puppet/parser/functions/ip_to_cron_spec.rb
+++ b/spec/unit/puppet/parser/functions/ip_to_cron_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'ip_to_cron' do
+describe 'ip_to_cron', type: :puppet_function do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it 'exists' do

--- a/spec/unit/puppet/parser/functions/random_password_spec.rb
+++ b/spec/unit/puppet/parser/functions/random_password_spec.rb
@@ -1,17 +1,17 @@
 require 'spec_helper'
 
-describe 'random_password' do
+describe 'random_password', type: :puppet_function do
   it { expect(subject).not_to eq(nil) }
   it { is_expected.not_to eq(nil) }
   it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError) }
 
   it 'returns a string of length 4' do
-    expect(subject.call([4])).to be_an String
+    expect(subject.call([4])).to be_a String
     subject.call([4]).length == 4
   end
 
   it 'returns a string of length 32' do
-    expect(subject.call([32])).to be_an String
+    expect(subject.call([32])).to be_a String
     subject.call([32]).length == 32
   end
 end

--- a/spec/unit/puppet/parser/functions/resources_deep_merge_spec.rb
+++ b/spec/unit/puppet/parser/functions/resources_deep_merge_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'resources_deep_merge' do
+describe 'resources_deep_merge', type: :puppet_function do
   let(:resources) do
     {
       'one' => {


### PR DESCRIPTION
Moved all function spec tests to spec/unit/puppet/parser/functions
Added `type: :puppet_function` as required.  See
https://github.com/rodjek/rspec-puppet#example-groups

Closes #60