### PR TITLE
Bump min version_requirement for Puppet + dep

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,13 +16,13 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 3.2.0"
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_range": ">= 3.2.1"
+      "version_range": ">= 4.6.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump stdlib to the minimum version that should work under Puppet 4,
based on the metadata