### PR TITLE
Fix stdlib version requirement in metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_range": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
I noticed this because my dependency resolver barfed on it