### PR TITLE
Fix default_content puppet-strings tags

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,7 +6,7 @@
 **Functions**
 
 * [`cache_data`](#cache_data): Retrieves data from a cache file, or creates it with supplied data if the file doesn't exist  Useful for having data that's randomly generate
-* [`default_content`](#default_content): Takes an optional content and an optional template name and returns the contents of a file.  Examples:      $config_file_content = default_co
+* [`default_content`](#default_content): Takes an optional content and an optional template name and returns the contents of a file.
 * [`dump_args`](#dump_args): dump_args - prints the args to STDOUT in Pretty JSON format.  Useful for debugging purposes only. Ideally you would use this in conjunction w
 * [`echo`](#echo): This function output the variable content and its type to the debug log. It's similiar to the "notice" function but provides a better output 
 * [`extlib::has_module`](#extlibhas_module): A function that lets you know whether a specific module is on your modulepath.
@@ -43,33 +43,28 @@ Returns: `Any`
 
 ### default_content
 
-Type: Ruby 3.x API
+Type: Ruby 4.x API
 
-Takes an optional content and an optional template name and returns the
-contents of a file.
+Takes an optional content and an optional template name and returns the contents of a file.
 
-Examples:
+#### `default_content(Variant[Undef,String] $content, Variant[Undef,String] $template_name)`
 
-    $config_file_content = default_content($file_content, $template_location)
-    file { '/tmp/x':
-      ensure  => 'file',
-      content => $config_file_content,
-    }
+The default_content function.
 
-#### `default_content()`
+Returns: `Variant[Undef,String]` Returns the value of the content parameter if it's a non empty string.
+Otherwise returns the rendered output from `template_name`.
 
-Takes an optional content and an optional template name and returns the
-contents of a file.
+##### `content`
 
-Examples:
+Data type: `Variant[Undef,String]`
 
-    $config_file_content = default_content($file_content, $template_location)
-    file { '/tmp/x':
-      ensure  => 'file',
-      content => $config_file_content,
-    }
 
-Returns: `Any`
+
+##### `template_name`
+
+Data type: `Variant[Undef,String]`
+
+The path to an .erb or .epp template file or `undef`.
 
 ### dump_args
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -53,6 +53,7 @@ The default_content function.
 
 Returns: `Variant[Undef,String]` Returns the value of the content parameter if it's a non empty string.
 Otherwise returns the rendered output from `template_name`.
+Returns `undef` if both `content` and `template_name` are `undef`.
 
 ##### `content`
 

--- a/lib/puppet/functions/default_content.rb
+++ b/lib/puppet/functions/default_content.rb
@@ -4,10 +4,9 @@ Puppet::Functions.create_function(:default_content) do
   # @param content
   # @param template_name
   #   The path to an .erb or .epp template file or `undef`.
-  # @return [String]
+  # @return
   #   Returns the value of the content parameter if it's a non empty string.
   #   Otherwise returns the rendered output from `template_name`.
-  # @return [Undef]
   #   Returns `undef` if both `content` and `template_name` are `undef`.
   #
   # @example Using the function with a file resource.

--- a/lib/puppet/functions/default_content.rb
+++ b/lib/puppet/functions/default_content.rb
@@ -1,10 +1,16 @@
 Puppet::Functions.create_function(:default_content) do
-  # @summary Takes an optional content and an optional template name and
-  # returns the contents of a file.
-  # @param :content
-  # @param :template_name
+  # @summary Takes an optional content and an optional template name and returns the contents of a file.
+  #
+  # @param content
+  # @param template_name
+  #   The path to an .erb or .epp template file or `undef`.
   # @return [String]
-  # @example:
+  #   Returns the value of the content parameter if it's a non empty string.
+  #   Otherwise returns the rendered output from `template_name`.
+  # @return [Undef]
+  #   Returns `undef` if both `content` and `template_name` are `undef`.
+  #
+  # @example Using the function with a file resource.
   #   $config_file_content = default_content($file_content, $template_location)
   #   file { '/tmp/x':
   #     ensure  => 'file',


### PR DESCRIPTION
Puppet strings was exploding when trying to generate markdown.
`bundle exec rake strings:generate\[',,,,false,true']`

```
rake aborted!
NoMethodError: undefined method `[]' for nil:NilClass
(erb):53:in `block (2 levels) in render'
(erb):50:in `each'
(erb):50:in `block in render'
(erb):21:in `each'
(erb):21:in `render'
/home/alex/.rvm/gems/ruby-2.4.1/gems/puppet-strings-2.1.0/lib/puppet-strings/markdown/base.rb:167:in `render'
```

Fixing the `@params` tags fixed this.

The `@summary` tag needing fixing too. `@example` still doesn't work.
Looks like we're hitting https://tickets.puppetlabs.com/browse/PDOC-263