### PR TITLE
RFC: Namespace functions

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,8 +7,9 @@
 
 * [`cache_data`](#cache_data): Retrieves data from a cache file, or creates it with supplied data if the file doesn't exist
 * [`default_content`](#default_content): Takes an optional content and an optional template name and returns the contents of a file.
-* [`dump_args`](#dump_args): Prints the args to STDOUT in Pretty JSON format.
+* [`dump_args`](#dump_args): DEPRECATED.  Use the namespaced function [`extlib::dump_args`](#extlibdump_args) instead.
 * [`echo`](#echo): This function outputs the variable content and its type to the debug log. It's similiar to the `notice` function but provides a better output
+* [`extlib::dump_args`](#extlibdump_args): Prints the args to STDOUT in Pretty JSON format.
 * [`extlib::has_module`](#extlibhas_module): A function that lets you know whether a specific module is on your modulepath.
 * [`extlib::sort_by_version`](#extlibsort_by_version): A function that sorts an array of version numbers
 * [`ip_to_cron`](#ip_to_cron): Provides a "random" value to cron based on the last bit of the machine IP address. used to avoid starting a certain cron job at the same time
@@ -89,27 +90,19 @@ The path to an .erb or .epp template file or `undef`.
 
 Type: Ruby 4.x API
 
-Prints the args to STDOUT in Pretty JSON format.
+DEPRECATED.  Use the namespaced function [`extlib::dump_args`](#extlibdump_args) instead.
 
-Useful for debugging purposes only. Ideally you would use this in
-conjunction with a rspec-puppet unit test.  Otherwise the output will
-be shown during a puppet run when verbose/debug options are enabled.
+#### `dump_args(Any *$args)`
 
-#### `dump_args(Any $args)`
+DEPRECATED.  Use the namespaced function [`extlib::dump_args`](#extlibdump_args) instead.
 
-Prints the args to STDOUT in Pretty JSON format.
+Returns: `Any`
 
-Useful for debugging purposes only. Ideally you would use this in
-conjunction with a rspec-puppet unit test.  Otherwise the output will
-be shown during a puppet run when verbose/debug options are enabled.
-
-Returns: `Undef` Returns nothing.
-
-##### `args`
+##### `*args`
 
 Data type: `Any`
 
-The data you want to dump as pretty JSON.
+
 
 ### echo
 
@@ -192,6 +185,32 @@ The value you want to inspect.
 Data type: `Optional[String]`
 
 An optional comment to prepend to the debug output.
+
+### extlib::dump_args
+
+Type: Ruby 4.x API
+
+Prints the args to STDOUT in Pretty JSON format.
+
+Useful for debugging purposes only. Ideally you would use this in
+conjunction with a rspec-puppet unit test.  Otherwise the output will
+be shown during a puppet run when verbose/debug options are enabled.
+
+#### `extlib::dump_args(Any $args)`
+
+Prints the args to STDOUT in Pretty JSON format.
+
+Useful for debugging purposes only. Ideally you would use this in
+conjunction with a rspec-puppet unit test.  Otherwise the output will
+be shown during a puppet run when verbose/debug options are enabled.
+
+Returns: `Undef` Returns nothing.
+
+##### `args`
+
+Data type: `Any`
+
+The data you want to dump as pretty JSON.
 
 ### extlib::has_module
 

--- a/lib/puppet/functions/dump_args.rb
+++ b/lib/puppet/functions/dump_args.rb
@@ -1,20 +1,11 @@
-require 'json'
-
-# @summary Prints the args to STDOUT in Pretty JSON format.
-#
-# Prints the args to STDOUT in Pretty JSON format.
-#
-# Useful for debugging purposes only. Ideally you would use this in
-# conjunction with a rspec-puppet unit test.  Otherwise the output will
-# be shown during a puppet run when verbose/debug options are enabled.
+# @summary DEPRECATED.  Use the namespaced function [`extlib::dump_args`](#extlibdump_args) instead.
+# DEPRECATED.  Use the namespaced function [`extlib::dump_args`](#extlibdump_args) instead.
 Puppet::Functions.create_function(:dump_args) do
-  # @param args The data you want to dump as pretty JSON.
-  # @return [Undef] Returns nothing.
-  dispatch :dump_args do
-    param 'Any', :args
+  dispatch :deprecation_gen do
+    repeated_param 'Any', :args
   end
-
-  def dump_args(args)
-    puts JSON.pretty_generate(args)
+  def deprecation_gen(*args)
+    call_function('deprecation', 'dump_args', 'This method is deprecated, please use extlib::dump_args instead.')
+    call_function('extlib::dump_args', *args)
   end
 end

--- a/lib/puppet/functions/extlib/dump_args.rb
+++ b/lib/puppet/functions/extlib/dump_args.rb
@@ -1,0 +1,20 @@
+require 'json'
+
+# @summary Prints the args to STDOUT in Pretty JSON format.
+#
+# Prints the args to STDOUT in Pretty JSON format.
+#
+# Useful for debugging purposes only. Ideally you would use this in
+# conjunction with a rspec-puppet unit test.  Otherwise the output will
+# be shown during a puppet run when verbose/debug options are enabled.
+Puppet::Functions.create_function(:'extlib::dump_args') do
+  # @param args The data you want to dump as pretty JSON.
+  # @return [Undef] Returns nothing.
+  dispatch :dump_args do
+    param 'Any', :args
+  end
+
+  def dump_args(args)
+    puts JSON.pretty_generate(args)
+  end
+end

--- a/spec/functions/extlib/dump_args_spec.rb
+++ b/spec/functions/extlib/dump_args_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'json'
+
+describe 'extlib::dump_args' do
+  it 'exists' do
+    is_expected.not_to be_nil
+  end
+
+  it 'requires an argument' do
+    is_expected.to run.with_params.and_raise_error(ArgumentError)
+  end
+
+  context 'when called with a hash' do
+    let(:hash) { { 'param_one' => 'value', 'param_two' => 42 } }
+
+    it 'puts pretty JSON' do
+      allow(STDOUT).to receive(:puts).with(JSON.pretty_generate(hash))
+      is_expected.to run.with_params(hash)
+    end
+  end
+
+  context 'when called with an integer' do
+    let(:int) { 42 }
+
+    it 'puts pretty JSON' do
+      allow(STDOUT).to receive(:puts).with(JSON.pretty_generate(int))
+      is_expected.to run.with_params(int)
+    end
+  end
+end


### PR DESCRIPTION
Keep the non namespaced functions for now, but generate a deprecation
warning.