### PR TITLE
Adds puppet debugger and debug module

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -8,5 +8,5 @@ spec/spec_helper.rb:
     - spec/fixtures/tmpdir/
 Rakefile:
   puppet_strings_patterns:
-    - lib/puppet/functions/extlib/*.rb
-    - functions/*.pp
+    - lib/puppet/functions/extlib/**/*.rb
+    - functions/**/*.pp

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ group :development do
   gem 'travis-lint',              :require => false
   gem 'guard-rake',               :require => false
   gem 'overcommit', '>= 0.39.1',  :require => false
+  gem 'puppet-debugger',          :require => false
 end
 
 group :system_tests do

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6,6 +6,7 @@
 **Functions**
 
 * [`extlib::cache_data`](#extlibcache_data): Retrieves data from a cache file, or creates it with supplied data if the file doesn't exist
+* [`extlib::debug::break`](#extlibdebugbreak): Injects a puppet debugger session where the break point was placed.
 * [`extlib::default_content`](#extlibdefault_content): Takes an optional content and an optional template name and returns the contents of a file.
 * [`extlib::dir_split`](#extlibdir_split): Splits the given directory or directories into individual paths.
 * [`extlib::dump_args`](#extlibdump_args): Prints the args to STDOUT in Pretty JSON format.
@@ -90,6 +91,112 @@ Cache key within the namespace
 Data type: `Any`
 
 The data for when there is no cache yet
+
+### extlib::debug::break
+
+Type: Ruby 4.x API
+
+This function allows you to set a breakpoint and break into the puppet compiler
+allowing you to interact with the puppet manifest.  Think of this like a 
+interactive manifest where the scope, facts and code is setup for you to play
+with in real time. This function is similar to binding.pry for ruby but instead
+is use solely  with the puppet debugger which is just for puppet code only.
+
+```ruby
+Ruby Version: 2.5.1
+Puppet Version: 6.4.0
+Puppet Debugger Version: 0.10.3
+Created by: NWOps <corey@nwops.io>
+Type "commands" for a list of debugger commands
+or "help" to show the help screen.
+
+        8:   service{'httpd': ensure => running}
+        9:    $var2 = ['value1', 'value2'] 
+        10:   # how to find values with an empheral scope
+        11:   $var2.each | String $item | {
+        12:     file{"/tmp/${item}": ensure => present}
+     => 13:     extlib::debug::break()
+        14:   }
+        15:   extlib::debug::break()
+        16:   if $var1 == 'value1' {
+        17:     extlib::debug::break()
+        18:   }
+1:>> $item
+=> "value1"
+````
+
+#### Examples
+
+##### How to find values with an empheral scope.
+
+```puppet
+$var2.each | String $item | {
+  file{"/tmp/${item}": ensure => present}
+  extlib::debug::break()
+}
+```
+
+##### - Insert a breakpoint anywhere in your puppet code.
+
+```puppet
+extlib::debug::break()
+```
+
+#### `extlib::debug::break(Optional[Hash] $options)`
+
+This function allows you to set a breakpoint and break into the puppet compiler
+allowing you to interact with the puppet manifest.  Think of this like a 
+interactive manifest where the scope, facts and code is setup for you to play
+with in real time. This function is similar to binding.pry for ruby but instead
+is use solely  with the puppet debugger which is just for puppet code only.
+
+```ruby
+Ruby Version: 2.5.1
+Puppet Version: 6.4.0
+Puppet Debugger Version: 0.10.3
+Created by: NWOps <corey@nwops.io>
+Type "commands" for a list of debugger commands
+or "help" to show the help screen.
+
+        8:   service{'httpd': ensure => running}
+        9:    $var2 = ['value1', 'value2'] 
+        10:   # how to find values with an empheral scope
+        11:   $var2.each | String $item | {
+        12:     file{"/tmp/${item}": ensure => present}
+     => 13:     extlib::debug::break()
+        14:   }
+        15:   extlib::debug::break()
+        16:   if $var1 == 'value1' {
+        17:     extlib::debug::break()
+        18:   }
+1:>> $item
+=> "value1"
+````
+
+Returns: `Integer` - returns the nunber of debugger instances currently alive
+
+##### Examples
+
+###### How to find values with an empheral scope.
+
+```puppet
+$var2.each | String $item | {
+  file{"/tmp/${item}": ensure => present}
+  extlib::debug::break()
+}
+```
+
+###### - Insert a breakpoint anywhere in your puppet code.
+
+```puppet
+extlib::debug::break()
+```
+
+##### `options`
+
+Data type: `Optional[Hash]`
+
+- a hash of puppet debugger options, not required
 
 ### extlib::default_content
 

--- a/Rakefile
+++ b/Rakefile
@@ -61,7 +61,7 @@ end
 
 desc 'Generate REFERENCE.md'
 task :reference, [:debug, :backtrace] do |t, args|
-  patterns = 'lib/puppet/functions/extlib/*.rb functions/*.pp'
+  patterns = 'lib/puppet/functions/extlib/**/*.rb functions/**/*.pp'
   Rake::Task['strings:generate:reference'].invoke(patterns, args[:debug], args[:backtrace])
 end
 

--- a/lib/puppet/functions/extlib/debug/break.rb
+++ b/lib/puppet/functions/extlib/debug/break.rb
@@ -1,0 +1,108 @@
+begin
+  require 'puppet-debugger'
+rescue LoadError => e
+  Puppet.err('You must install the puppet-debugger: gem install puppet-debugger')
+end
+
+# @summary Injects a puppet debugger session where the break point was placed.
+#
+# This function allows you to set a breakpoint and break into the puppet compiler
+# allowing you to interact with the puppet manifest.  Think of this like a 
+# interactive manifest where the scope, facts and code is setup for you to play
+# with in real time. This function is similar to binding.pry for ruby but instead
+# is use solely  with the puppet debugger which is just for puppet code only.
+#
+# ```ruby
+# Ruby Version: 2.5.1
+# Puppet Version: 6.4.0
+# Puppet Debugger Version: 0.10.3
+# Created by: NWOps <corey@nwops.io>
+# Type "commands" for a list of debugger commands
+# or "help" to show the help screen.
+#
+#         8:   service{'httpd': ensure => running}
+#         9:    $var2 = ['value1', 'value2'] 
+#         10:   # how to find values with an empheral scope
+#         11:   $var2.each | String $item | {
+#         12:     file{"/tmp/${item}": ensure => present}
+#      => 13:     extlib::debug::break()
+#         14:   }
+#         15:   extlib::debug::break()
+#         16:   if $var1 == 'value1' {
+#         17:     extlib::debug::break()
+#         18:   }
+# 1:>> $item
+# => "value1"
+# ````
+#
+# @example How to find values with an empheral scope.
+#  $var2.each | String $item | {
+#    file{"/tmp/${item}": ensure => present}
+#    extlib::debug::break()
+#  }
+#
+# @example - Insert a breakpoint anywhere in your puppet code.
+#   extlib::debug::break()
+#
+#
+Puppet::Functions.create_function(:'extlib::debug::break', Puppet::Functions::InternalFunction) do
+  # the function below is called by puppet and and must match
+  # the name of the puppet function above.
+
+  # The debugger_stack_count is used to determine if this function has already been called
+  # in order to prevent additionally help output from the debugger 
+
+  def initialize(scope, loader)
+    super
+    @debugger_stack_count = 0
+  end
+
+  # @return [Integer] - returns the nunber of debugger instances currently alive
+  # @param options [Hash] - a hash of puppet debugger options, not required
+  dispatch :break do
+    scope_param
+    optional_param 'Hash', :options
+  end
+
+  def break(scope, options = {})
+    if $stdout.isatty
+      options = options.merge({:scope => scope})
+      # forking the process allows us to start a new debugger shell
+      # for each occurrence of the start_debugger function
+      pid = fork do
+        # required in order to use convert puppet hash into ruby hash with symbols
+        options = options.inject({}){|data,(k,v)| data[k.to_sym] = v; data}
+        options[:source_file], options[:source_line] = stacktrace.last
+        # suppress future debugger help screens
+        @debugger_stack_count = @debugger_stack_count + 1
+        # suppress future debugger help screens since we probably started from the debugger, so look for this string
+        # in the filename to detect
+        @debugger_stack_count = @debugger_stack_count + 1 if options[:source_file] =~ /puppet_debugger_input/
+        options[:quiet] = true if @debugger_stack_count > 1
+        ::PuppetDebugger::Cli.start_without_stdin(options)
+      end
+      Process.wait(pid)
+      @debugger_stack_count = @debugger_stack_count + 1
+    else
+      Puppet.warning 'debug::breakpoint(): refusing to start the debugger on a daemonized master'
+    end
+  end
+
+  # returns a stacktrace of called puppet code
+  # @return [String] - file path to source code
+  # @return [Integer] - line number of called function
+  # This method originally came from the puppet 4.6 codebase and was backported here
+  # for compatibility with older puppet versions
+  # The basics behind this are to find the `.pp` file in the list of loaded code
+  def stacktrace
+    result = caller().reduce([]) do |memo, loc|
+      if loc =~ /\A(.*\.pp)?:([0-9]+):in\s(.*)/
+        # if the file is not found we set to code
+        # and read from Puppet[:code]
+        # $3 is reserved for the stacktrace type
+        memo << [$1.nil? ? :code : $1, $2.to_i]
+      end
+      memo
+    end.reverse
+  end
+end

--- a/metadata.json
+++ b/metadata.json
@@ -8,11 +8,7 @@
   "license": "Apache-2.0",
   "summary": "extlib provides functions out of scope puppetlabs/stdlib",
   "description": "extlib provides functions out of scope puppetlabs/stdlib",
-  "tags": [
-    "voxpupuli",
-    "extlib",
-    "stdlib"
-  ],
+  "tags": ["voxpupuli", "extlib", "stdlib"],
   "requirements": [
     {
       "name": "puppet",
@@ -28,39 +24,23 @@
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
+      "operatingsystemrelease": ["6", "7"]
     },
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
+      "operatingsystemrelease": ["6", "7"]
     },
     {
       "operatingsystem": "Scientific",
-      "operatingsystemrelease": [
-        "6",
-        "7"
-      ]
+      "operatingsystemrelease": ["6", "7"]
     },
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8",
-        "9"
-      ]
+      "operatingsystemrelease": ["8", "9"]
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [
-        "14.04",
-        "16.04",
-        "18.04"
-      ]
+      "operatingsystemrelease": ["14.04", "16.04", "18.04"]
     }
   ]
 }

--- a/spec/functions/extlib/debug/break_spec.rb
+++ b/spec/functions/extlib/debug/break_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+require 'puppet-debugger'
+
+describe 'extlib::debug::break' do
+ 
+  it do 
+    allow(PuppetDebugger::Cli).to receive(:start_without_stdin).with({:scope=>anything, :source_file=>nil, :source_line=>nil}).and_return(true)
+    # 1 is the number of debugger instances currently running
+    is_expected.to run.with_params().and_return(1)
+  end
+end


### PR DESCRIPTION
  * Previously there was not a way to debug puppet code.
    The puppet debugger gives us a pry-like console for
    finding bugs in our code without resorting to print
    or dump statements.
  * The debug module gives us a way to break into our code
    just like like the binding.pry method does except the function
    is debug::break().
  * Also adds the puppet-debugger gem to the gemfile as it is required
    when using the debug::break() function.
  * While this commit does not create a new function it merely
    list the debug module as a dependency.


