### PR TITLE
Improve `extlib::path_join` docs formatting

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -436,16 +436,16 @@ path will work on windows.
 
 #### Examples
 
-##### extlib::path_join('/tmp', 'test', 'libs') returns '/tmp/test/libs'
+##### Joining Unix paths to return `/tmp/test/libs`
 
 ```puppet
-
+extlib::path_join('/tmp', 'test', 'libs')
 ```
 
-##### extlib::path_join('c:', 'test', 'libs') returns '/c/test/libs'
+##### Joining Windows paths to return `/c/test/libs`
 
 ```puppet
-
+extlib::path_join('c:', 'test', 'libs')
 ```
 
 #### `extlib::path_join(Array[String] $dirs)`
@@ -454,27 +454,27 @@ Because in how windows uses a different separator this function
 will format a windows path into a equilivent unix like path.  This type of unix like
 path will work on windows.
 
-Returns: `Stdlib::Absolutepath` - The joined path
+Returns: `Stdlib::Absolutepath` The joined path
 
 ##### Examples
 
-###### extlib::path_join('/tmp', 'test', 'libs') returns '/tmp/test/libs'
+###### Joining Unix paths to return `/tmp/test/libs`
 
 ```puppet
-
+extlib::path_join('/tmp', 'test', 'libs')
 ```
 
-###### extlib::path_join('c:', 'test', 'libs') returns '/c/test/libs'
+###### Joining Windows paths to return `/c/test/libs`
 
 ```puppet
-
+extlib::path_join('c:', 'test', 'libs')
 ```
 
 ##### `dirs`
 
 Data type: `Array[String]`
 
-- Joins two or more directories by file separator.
+Joins two or more directories by file separator.
 
 ### extlib::random_password
 

--- a/functions/path_join.pp
+++ b/functions/path_join.pp
@@ -3,10 +3,12 @@
 # will format a windows path into a equilivent unix like path.  This type of unix like
 # path will work on windows.
 #
-# @param dirs [Array[String]] - Joins two or more directories by file separator.
-# @return [Stdlib::Absolutepath] - The joined path
-# @example extlib::path_join('/tmp', 'test', 'libs') returns '/tmp/test/libs'
-# @example extlib::path_join('c:', 'test', 'libs') returns '/c/test/libs'
+# @param dirs Joins two or more directories by file separator.
+# @return [Stdlib::Absolutepath] The joined path
+# @example Joining Unix paths to return `/tmp/test/libs`
+#   extlib::path_join('/tmp', 'test', 'libs')
+# @example Joining Windows paths to return `/c/test/libs`
+#   extlib::path_join('c:', 'test', 'libs')
 function extlib::path_join(Array[String] $dirs) >> Stdlib::Absolutepath {
   $unix_sep = '/'
   $sep_regex = /\/|\\/


### PR DESCRIPTION
The recently released Puppet Strings 2.2 parses `@example` and so this
function needed a small cleanup to improve the outputted `REFERENCE.md`