### PR TITLE
Add experimental `extlib::read_url` function

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,6 +16,7 @@
 * [`extlib::mkdir_p`](#extlibmkdir_p): Like the unix command mkdir_p except with puppet code.
 * [`extlib::path_join`](#extlibpath_join): Take one or more paths and join them together using the os specific separator.
 * [`extlib::random_password`](#extlibrandom_password): A function to return a string of arbitrary length that contains randomly selected characters.
+* [`extlib::read_url`](#extlibread_url): Fetch a string from a URL (should only be used with 'small' remote files).  This function should only be used with trusted/internal sources. 
 * [`extlib::resources_deep_merge`](#extlibresources_deep_merge): Deeply merge a "defaults" hash into a "resources" hash like the ones expected by `create_resources()`.
 * [`extlib::sort_by_version`](#extlibsort_by_version): A function that sorts an array of version numbers.
 
@@ -509,6 +510,52 @@ random_password(42)
 Data type: `Integer[1]`
 
 The length of random password you want generated.
+
+### extlib::read_url
+
+Type: Ruby 4.x API
+
+Fetch a string from a URL (should only be used with 'small' remote files).
+
+This function should only be used with trusted/internal sources.
+This is especially important if using it in conjunction with `inline_template`
+or `inline_epp`.
+The current implementation is also very basic.  No thought has gone into timeouts,
+support for redirects, CA paths etc.
+
+#### Examples
+
+##### Calling the function
+
+```puppet
+extlib::read_url('https://example.com/sometemplate.epp')
+```
+
+#### `extlib::read_url(Stdlib::HTTPUrl $url)`
+
+Fetch a string from a URL (should only be used with 'small' remote files).
+
+This function should only be used with trusted/internal sources.
+This is especially important if using it in conjunction with `inline_template`
+or `inline_epp`.
+The current implementation is also very basic.  No thought has gone into timeouts,
+support for redirects, CA paths etc.
+
+Returns: `String` Returns the contents of the url as a string
+
+##### Examples
+
+###### Calling the function
+
+```puppet
+extlib::read_url('https://example.com/sometemplate.epp')
+```
+
+##### `url`
+
+Data type: `Stdlib::HTTPUrl`
+
+The URL to read from
 
 ### extlib::resources_deep_merge
 

--- a/lib/puppet/functions/extlib/read_url.rb
+++ b/lib/puppet/functions/extlib/read_url.rb
@@ -1,0 +1,23 @@
+# Fetch a string from a URL (should only be used with 'small' remote files).
+#
+# This function should only be used with trusted/internal sources.
+# This is especially important if using it in conjunction with `inline_template`
+# or `inline_epp`.
+# The current implementation is also very basic.  No thought has gone into timeouts,
+# support for redirects, CA paths etc.
+Puppet::Functions.create_function(:'extlib::read_url') do
+  # @param url The URL to read from
+  # @return Returns the contents of the url as a string
+  # @example Calling the function
+  #   extlib::read_url('https://example.com/sometemplate.epp')
+  dispatch :read_url do
+    param 'Stdlib::HTTPUrl', :url
+    return_type 'String'
+  end
+
+  def read_url(url)
+    require 'open-uri'
+    uri = URI.parse(url)
+    uri.read
+  end
+end

--- a/spec/functions/extlib/read_url_spec.rb
+++ b/spec/functions/extlib/read_url_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'extlib::read_url' do
+  it { is_expected.not_to eq(nil) }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+
+  context 'when called with a valid url' do
+    it 'returns the content of the url' do
+      returned_data = subject.execute('https://raw.githubusercontent.com/voxpupuli/puppet-extlib/master/README.md')
+      expect(returned_data).to include('Extlib module for Puppet')
+    end
+  end
+end


### PR DESCRIPTION
I knocked this together to solve a use-case presented on the slack channel.  The user wanted to use `inline_tempate` with a template from a URL (as opposed to one stored in a module).

What could possibly go wrong...

ok.  So I wouldn't recommend trying to read anything other than 'small' files.
I'd also recommend doing something in the calling puppet to give you confidence you've not been returned junk.

Maybe someone will want to add some extra parameters in the future.  Some sort of timeout would probably be a good idea.