### PR TITLE
puppet_config: no need to confine to linux

### DIFF
--- a/lib/facter/puppet_config.rb
+++ b/lib/facter/puppet_config.rb
@@ -14,7 +14,6 @@ desired_settings = {
   ]
 }
 Facter.add(:puppet_config) do
-  confine kernel: 'Linux'
   puppet_config = {}
   setcode do
     desired_settings.each_pair do |section, settings|


### PR DESCRIPTION
As mentioned by @vchepkov in https://github.com/voxpupuli/puppet-extlib/pull/143#discussion_r371002507 `  confine kernel: 'Linux'` is not required