### PR TITLE
Remove strings patterns

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -6,7 +6,3 @@ spec/spec_helper.rb:
 .gitignore:
   paths:
     - spec/fixtures/tmpdir/
-Rakefile:
-  puppet_strings_patterns:
-    - lib/puppet/functions/extlib/*.rb
-    - functions/*.pp

--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ end
 
 desc 'Generate REFERENCE.md'
 task :reference, [:debug, :backtrace] do |t, args|
-  patterns = 'lib/puppet/functions/extlib/*.rb functions/*.pp'
+  patterns = ''
   Rake::Task['strings:generate:reference'].invoke(patterns, args[:debug], args[:backtrace])
 end
 


### PR DESCRIPTION
cb774c01d0bed59a88a9e5785d1afff8a4b8b786 removed the deprecated functions which means it's no longer needed to add this override.