### PR TITLE
path_join: fix examples

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -476,13 +476,13 @@ path will work on windows.
 ##### Joining Unix paths to return `/tmp/test/libs`
 
 ```puppet
-extlib::path_join('/tmp', 'test', 'libs')
+extlib::path_join(['/tmp', 'test', 'libs'])
 ```
 
 ##### Joining Windows paths to return `/c/test/libs`
 
 ```puppet
-extlib::path_join('c:', 'test', 'libs')
+extlib::path_join(['c:', 'test', 'libs'])
 ```
 
 #### `extlib::path_join(Array[String] $dirs)`
@@ -498,13 +498,13 @@ Returns: `Stdlib::Absolutepath` The joined path
 ###### Joining Unix paths to return `/tmp/test/libs`
 
 ```puppet
-extlib::path_join('/tmp', 'test', 'libs')
+extlib::path_join(['/tmp', 'test', 'libs'])
 ```
 
 ###### Joining Windows paths to return `/c/test/libs`
 
 ```puppet
-extlib::path_join('c:', 'test', 'libs')
+extlib::path_join(['c:', 'test', 'libs'])
 ```
 
 ##### `dirs`

--- a/functions/path_join.pp
+++ b/functions/path_join.pp
@@ -6,9 +6,9 @@
 # @param dirs Joins two or more directories by file separator.
 # @return [Stdlib::Absolutepath] The joined path
 # @example Joining Unix paths to return `/tmp/test/libs`
-#   extlib::path_join('/tmp', 'test', 'libs')
+#   extlib::path_join(['/tmp', 'test', 'libs'])
 # @example Joining Windows paths to return `/c/test/libs`
-#   extlib::path_join('c:', 'test', 'libs')
+#   extlib::path_join(['c:', 'test', 'libs'])
 function extlib::path_join(Array[String] $dirs) >> Stdlib::Absolutepath {
   $unix_sep = '/'
   $sep_regex = /\/|\\/


### PR DESCRIPTION
It takes an array of strings, not multiple string arguments.