### PR TITLE
Remove namespaced `extlib.puppet_config` fact

### DIFF
--- a/lib/facter/extlib__puppet_config.rb
+++ b/lib/facter/extlib__puppet_config.rb
@@ -30,10 +30,3 @@ Facter.add(:extlib__puppet_config) do
     puppet_config
   end
 end
-
-# Facter 4 namespaced version
-Facter.add(:'extlib.puppet_config') do
-  setcode do
-    Facter.value(:extlib__puppet_config)
-  end
-end

--- a/spec/unit/facter/extlib__puppet_config_spec.rb
+++ b/spec/unit/facter/extlib__puppet_config_spec.rb
@@ -22,10 +22,4 @@ describe 'extlib__puppet_config fact' do
   end
 
   it { expect(Facter.fact(:extlib__puppet_config).value).to eq(settings) }
-
-  if Gem::Version.new(Gem.loaded_specs['facter'].version) >= Gem::Version.new('4')
-    it 'is also available under the toplevel `extlib` structured fact' do
-      expect(Facter.fact(:extlib).value).to include('puppet_config' => settings)
-    end
-  end
 end


### PR DESCRIPTION
Early versions of Facter 4 supported creating structured facts by
aggregating multiple dotted facts.

ie `extlib.puppet_config` would become the `puppet_config` key of a top
level structured fact `extlib`.

This behaviour caused too many issues with the existing ecosystem so was
removed in https://github.com/puppetlabs/facter/pull/2339

namespacing for facts might still return.

Quoting @gimmyxd on slack...
```
currently there is no way to switch the auto conversion per fact.  We
are still working on finding the best mechanism to allow enabling dotted
structured facts and ensure a smooth transition from Facter 3 to this
new behaviour: https://tickets.puppetlabs.com/browse/FACT-3000
```