### PR TITLE
extlib::dump_params: Return the parameters pass to the current resource

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -13,6 +13,7 @@
 * [`extlib::dir_clean`](#extlibdir_clean): Take a path and normalise it to its Unix form.
 * [`extlib::dir_split`](#extlibdir_split): Splits the given directory or directories into individual paths.
 * [`extlib::dump_args`](#extlibdump_args): Prints the args to STDOUT in Pretty JSON format.
+* [`extlib::dump_params`](#extlibdump_params): this function is used to get a list of parameters passed to or resource.
 * [`extlib::echo`](#extlibecho): This function outputs the variable content and its type to the debug log. It's similiar to the `notice` function but provides a better output
 * [`extlib::file_separator`](#extlibfile_separator): Returns the os specific file path separator.
 * [`extlib::has_module`](#extlibhas_module): A function that lets you know whether a specific module is on your modulepath.
@@ -332,6 +333,84 @@ Returns: `Undef` Returns nothing.
 Data type: `Any`
 
 The data you want to dump as pretty JSON.
+
+### <a name="extlibdump_params"></a>`extlib::dump_params`
+
+Type: Ruby 4.x API
+
+this function is used to get a list of parameters passed to or resource.
+
+#### Examples
+
+##### The main two use cases the author envisage for this function are:
+
+```puppet
+* Passing Parameters from a profile straight though to a base class
+We Often aver profiles that pass all, or almost all parameters directly to a base class,
+this function allows us to more easily pass theses parameters through with out a lot of addtional
+copy and paste e.g.
+
+    class profile::foobar ($param1, $param2) {
+    class { 'foobar':
+      *                => extlib::dump_params,
+      additional_param => 'foobar',
+    }
+  }
+
+* Passing parmaters directly to a config file.
+  Another pattern one often sees, are classes where the majority of parameters get passed straight
+  through to some config file.  This function allows us to more easily manage such templating e.g.
+
+  class foobar ($app_param1, $app_param2, $class_param1) {
+    file { '/etc/foo/config.yaml':
+      ensure => file,
+      # class param and name are not understoof by the foo app
+      content => extlib::dump_params(['name', 'class_param1']).to_yaml
+    }
+  }
+```
+
+#### `extlib::dump_params(Optional[Array[String[1]]] $filter_keys)`
+
+The extlib::dump_params function.
+
+Returns: `Any`
+
+##### Examples
+
+###### The main two use cases the author envisage for this function are:
+
+```puppet
+* Passing Parameters from a profile straight though to a base class
+We Often aver profiles that pass all, or almost all parameters directly to a base class,
+this function allows us to more easily pass theses parameters through with out a lot of addtional
+copy and paste e.g.
+
+    class profile::foobar ($param1, $param2) {
+    class { 'foobar':
+      *                => extlib::dump_params,
+      additional_param => 'foobar',
+    }
+  }
+
+* Passing parmaters directly to a config file.
+  Another pattern one often sees, are classes where the majority of parameters get passed straight
+  through to some config file.  This function allows us to more easily manage such templating e.g.
+
+  class foobar ($app_param1, $app_param2, $class_param1) {
+    file { '/etc/foo/config.yaml':
+      ensure => file,
+      # class param and name are not understoof by the foo app
+      content => extlib::dump_params(['name', 'class_param1']).to_yaml
+    }
+  }
+```
+
+##### `filter_keys`
+
+Data type: `Optional[Array[String[1]]]`
+
+an optional parameters of keys to filter out.  default value is set to 'name'
 
 ### <a name="extlibecho"></a>`extlib::echo`
 

--- a/lib/puppet/functions/extlib/dump_params.rb
+++ b/lib/puppet/functions/extlib/dump_params.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# @summary this function is used to get a list of parameters passed to or resource.
+# @example The main two use cases the author envisage for this function are:
+#   * Passing Parameters from a profile straight though to a base class
+#   We Often aver profiles that pass all, or almost all parameters directly to a base class,
+#   this function allows us to more easily pass theses parameters through with out a lot of addtional
+#   copy and paste e.g.
+#
+#       class profile::foobar ($param1, $param2) {
+#       class { 'foobar':
+#         *                => extlib::dump_params,
+#         additional_param => 'foobar',
+#       }
+#     }
+#
+#   * Passing parmaters directly to a config file.
+#     Another pattern one often sees, are classes where the majority of parameters get passed straight
+#     through to some config file.  This function allows us to more easily manage such templating e.g.
+#
+#     class foobar ($app_param1, $app_param2, $class_param1) {
+#       file { '/etc/foo/config.yaml':
+#         ensure => file,
+#         # class param and name are not understoof by the foo app
+#         content => extlib::dump_params(['name', 'class_param1']).to_yaml
+#       }
+#     }
+#
+Puppet::Functions.create_function(:'extlib::dump_params', Puppet::Functions::InternalFunction) do
+  # @param filter_keys an optional parameters of keys to filter out.  default value is set to 'name'
+  dispatch :dump_params do
+    scope_param
+    optional_param 'Array[String[1]]', :filter_keys
+  end
+
+  def dump_params(scope, filter_keys = ['name'])
+    scope.resource.to_hash.transform_keys(&:to_s).reject { |k, _v| filter_keys.include?(k) }
+  end
+end

--- a/spec/functions/extlib/dump_params_spec.rb
+++ b/spec/functions/extlib/dump_params_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'extlib::dump_params' do
+  it 'exists' do
+    is_expected.not_to be_nil
+  end
+
+  it 'requires an argument' do
+    is_expected.to run.and_return({})
+  end
+
+  describe 'mock resource' do
+    before do
+      allow(scope).to receive(:resource).and_return(foo: 'foo', bar: 'bar')
+    end
+
+    it 'convert symbols to strings' do
+      is_expected.to run.and_return('foo' => 'foo', 'bar' => 'bar')
+    end
+
+    it 'filter bar' do
+      is_expected.to run.with_params(['bar']).and_return('foo' => 'foo')
+    end
+
+    it 'filter foo' do
+      is_expected.to run.with_params(['foo']).and_return('bar' => 'bar')
+    end
+  end
+end


### PR DESCRIPTION
I often find my self wrinting classes where parameters are mapped directly
into a config file e.g.

```puppet
class 'foobar' (
  $log_dir = '/var/logs/foobar',
  $user    = 'foobar'
) {
  file { $log_dir:
    ensure => directory,
  }
  user { $user:
    ensure => present,
  }
  config => {
    'log_dir' => $log_dir,
    'user'    => $user,
  }
  file { '/etc/foobar/yaml':
    ensure => file,
    content => $config.to_yaml,
  }
}
```

This new function allows us to simplify the content generation of the
config file using e.g.
```puppet
  file { '/etc/foobar/yaml':
    ensure => file,
    content => extlib::dump_params.to_yaml,
  }
```

This is also useful to pass values from a profile to a class e.g.

```puppet
class profile::apache (
  $docroot = '/srv/www',
  $group   = 'www-data',
) {
  class { 'apache':
    * => extlib::dump_params
  }
}
```
Real world examples:
  * https://github.com/wikimedia/puppet/commit/403d952e98a2fab3270a3c8be9a293c1b3545b56
  * https://gerrit.wikimedia.org/r/c/operations/puppet/+/753786
    (not merged yet hence the gerrit link, however it is a noop)

