### PR TITLE
RFC: add extlib::to_ini() function

### DIFF
--- a/lib/puppet/functions/extlib/to_ini.rb
+++ b/lib/puppet/functions/extlib/to_ini.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# @summary
+#   This converts a puppet hash to an INI string.
+#
+#   Based on https://github.com/mmckinst/puppet-hash2stuff/blob/master/lib/puppet/parser/functions/hash2ini.rb
+#
+# @example How to output ini to a file
+#   file { '/tmp/config.ini':
+#     ensure  => file,
+#     content => extlib::to_ini($myhash),
+#   }
+Puppet::Functions.create_function(:'extlib::to_ini') do
+  # @param data Data structure which needs to be converted into ini
+  # @param settings Override default ini generation settings
+  # @return [String] Converted data as ini string
+  dispatch :to_ini do
+    required_param 'Hash', :data
+    optional_param 'Hash', :settings
+    return_type 'String'
+  end
+
+  def to_ini(data, settings = {})
+    default_settings = {
+      'header'            => '# THIS FILE IS CONTROLLED BY PUPPET',
+      'section_prefix'    => '[',
+      'section_suffix'    => ']',
+      'key_val_separator' => '=',
+      'quote_char'        => '"',
+      'quote_booleans'    => true,
+      'quote_numerics'    => true,
+    }
+
+    settings = default_settings.merge(settings)
+
+    ini = []
+    ini << settings['header'] << nil
+    data.each_key do |section|
+      ini << "#{settings['section_prefix']}#{section}#{settings['section_suffix']}"
+      data[section].each do |k, v|
+        v_is_a_boolean = (v.is_a?(TrueClass) or v.is_a?(FalseClass))
+
+        ini << if (v_is_a_boolean && !(settings['quote_booleans'])) || (v.is_a?(Numeric) && !(settings['quote_numerics']))
+                 "#{k}#{settings['key_val_separator']}#{v}"
+               else
+                 "#{k}#{settings['key_val_separator']}#{settings['quote_char']}#{v}#{settings['quote_char']}"
+               end
+      end
+      ini << nil
+    end
+    ini.join("\n")
+  end
+end

--- a/spec/functions/extlib/to_ini_spec.rb
+++ b/spec/functions/extlib/to_ini_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'extlib::to_ini' do
+  let(:example_input) do
+    {
+      'main' => {
+        'logging' => 'INFO',
+        'limit'   => 314,
+        'awesome' => true,
+      },
+      'dev' => {
+        'logging'      => 'DEBUG',
+        'log_location' => '/var/log/dev.log',
+      }
+    }
+  end
+
+  it { is_expected.not_to eq(nil) }
+
+  context 'default settings' do
+    let(:output) do
+      <<~EOS
+        # THIS FILE IS CONTROLLED BY PUPPET
+
+        [main]
+        logging="INFO"
+        limit="314"
+        awesome="true"
+
+        [dev]
+        logging="DEBUG"
+        log_location="/var/log/dev.log"
+      EOS
+    end
+
+    it { is_expected.to run.with_params(example_input).and_return(output) }
+  end
+
+  context 'custom settings' do
+    let(:settings) do
+      {
+        'header' => '; THIS FILE IS CONTROLLED BY /dev/random',
+        'section_prefix' => '[[',
+        'section_suffix' => ']]',
+        'key_val_separator' => ': ',
+        'quote_char' => '',
+      }
+    end
+    let(:output) do
+      <<~EOS
+        ; THIS FILE IS CONTROLLED BY /dev/random
+
+        [[main]]
+        logging: INFO
+        limit: 314
+        awesome: true
+
+        [[dev]]
+        logging: DEBUG
+        log_location: /var/log/dev.log
+      EOS
+    end
+
+    it { is_expected.to run.with_params(example_input, settings).and_return(output) }
+  end
+
+  context 'default settings with custom quoting' do
+    let(:settings) do
+      {
+        'quote_booleans' => false,
+        'quote_numerics' => false,
+      }
+    end
+    let(:output) do
+      <<~EOS
+        # THIS FILE IS CONTROLLED BY PUPPET
+
+        [main]
+        logging="INFO"
+        limit=314
+        awesome=true
+
+        [dev]
+        logging="DEBUG"
+        log_location="/var/log/dev.log"
+      EOS
+    end
+
+    it { is_expected.to run.with_params(example_input, settings).and_return(output) }
+  end
+end

--- a/spec/functions/extlib/to_ini_spec.rb
+++ b/spec/functions/extlib/to_ini_spec.rb
@@ -90,4 +90,24 @@ describe 'extlib::to_ini' do
 
     it { is_expected.to run.with_params(example_input, settings).and_return(output) }
   end
+
+  context 'default settings with empty sections' do
+    let(:example_input) do
+      {
+        'foo' => {},
+        'bar' => {}
+      }
+    end
+    let(:output) do
+      <<~EOS
+        # THIS FILE IS CONTROLLED BY PUPPET
+
+        [foo]
+
+        [bar]
+      EOS
+    end
+
+    it { is_expected.to run.with_params(example_input).and_return(output) }
+  end
 end


### PR DESCRIPTION
Based on / copied from:

https://github.com/mmckinst/puppet-hash2stuff/blob/master/lib/puppet/parser/functions/hash2ini.rb

The original author, @mmckinst, claims to have haulted support for this
code and has stated no objection to this function being migrated to
extlib:

https://github.com/mmckinst/puppet-hash2stuff/issues/19

The original hash2ini() function was rejected from stdlib:

https://github.com/puppetlabs/puppetlabs-stdlib/pull/620