### PR TITLE
Demo ghostbuster bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :test do
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
   gem 'puppet_metadata', '~> 3.5',  :require => false
+  gem 'puppet-ghostbuster', '1.2.0',:require => false
 end
 
 group :development do


### PR DESCRIPTION
DO NOT MERGE

If puppet-ghostbuster is in your Gemfile, puppet-lint is broken.

This is just a PR to demo https://github.com/voxpupuli/puppet-ghostbuster/issues/89