### PR TITLE
extlib__puppet_config: Add environment settings

### DIFF
--- a/lib/facter/extlib__puppet_config.rb
+++ b/lib/facter/extlib__puppet_config.rb
@@ -17,7 +17,9 @@ Facter.add(:extlib__puppet_config) do
         ssldir
         vardir
         server
-      ]
+        environment
+      ],
+      agent: %i[environment],
     }
 
     desired_settings.each_pair do |section, settings|

--- a/spec/unit/facter/extlib__puppet_config_spec.rb
+++ b/spec/unit/facter/extlib__puppet_config_spec.rb
@@ -14,11 +14,15 @@ describe 'extlib__puppet_config fact' do
         'localcacert' => '/dev/null/ssl/certs/ca.pem',
         'server' => 'puppet',
         'ssldir' => '/dev/null/ssl',
-        'vardir' => '/dev/null'
+        'vardir' => '/dev/null',
+        'environment' => 'production'
       },
       'master' => {
         'localcacert' => '/dev/null/ssl/certs/ca.pem',
         'ssldir' => '/dev/null/ssl'
+      },
+      'agent' => {
+        'environment' => 'production'
       }
     }
   end


### PR DESCRIPTION
```json
{
  "extlib__puppet_config": {
    "master": {
      "localcacert": "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
      "ssldir": "/etc/puppetlabs/puppet/ssl"
    },
    "main": {
      "hostpubkey": "/etc/puppetlabs/puppet/ssl/public_keys/puppet.local.pem",
      "hostprivkey": "/etc/puppetlabs/puppet/ssl/private_keys/puppet.local.pem",
      "hostcert": "/etc/puppetlabs/puppet/ssl/certs/puppet.local.pem",
      "localcacert": "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
      "ssldir": "/etc/puppetlabs/puppet/ssl",
      "vardir": "/opt/puppetlabs/puppet/cache",
      "server": "puppet.local",
      "environment": "production"
    },
    "agent": {
      "environment": "production"
    }
  }
}
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
