### PR TITLE
clean_blank_lines: Add a new function to clean blank Lines

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -29,6 +29,7 @@ Thus making it directly usable with the values from facter.
 * [`extlib::random_password`](#extlib--random_password): A function to return a string of arbitrary length that contains randomly selected characters.
 * [`extlib::read_url`](#extlib--read_url): Fetch a string from a URL (should only be used with 'small' remote files).  This function should only be used with trusted/internal sources. 
 * [`extlib::remote_pql_query`](#extlib--remote_pql_query): Perform a PuppetDB query on an arbitrary PuppetDB server  If you need to query a PuppetDB server that is not connected to your Puppet Server 
+* [`extlib::remove_blank_lines`](#extlib--remove_blank_lines): Remove blank lines from a string
 * [`extlib::resources_deep_merge`](#extlib--resources_deep_merge): Deeply merge a "defaults" hash into a "resources" hash like the ones expected by `create_resources()`.
 * [`extlib::sort_by_version`](#extlib--sort_by_version): A function that sorts an array of version numbers.
 * [`extlib::to_ini`](#extlib--to_ini): This converts a puppet hash to an INI string.
@@ -1053,6 +1054,24 @@ The PuppetDB HTTP URL (non SSL version)
 Data type: `Optional[Hash]`
 
 PuppetDB query options. (See https://www.puppet.com/docs/puppetdb/8/api/query/v4/paging)
+
+### <a name="extlib--remove_blank_lines"></a>`extlib::remove_blank_lines`
+
+Type: Puppet Language
+
+Remove blank lines from a string
+
+#### `extlib::remove_blank_lines(String[1] $content)`
+
+The extlib::remove_blank_lines function.
+
+Returns: `String[1]` The content with blank lines removed
+
+##### `content`
+
+Data type: `String[1]`
+
+The content to remove blank lines from
 
 ### <a name="extlib--resources_deep_merge"></a>`extlib::resources_deep_merge`
 

--- a/functions/remove_blank_lines.pp
+++ b/functions/remove_blank_lines.pp
@@ -1,0 +1,8 @@
+# @summary Remove blank lines from a string
+# @param content The content to remove blank lines from
+# @return The content with blank lines removed
+function extlib::remove_blank_lines (
+  String[1] $content,
+) >> String[1] {
+  return $content.split("\n").filter |$x| { !$x.empty }.join("\n")
+}

--- a/spec/functions/remove_blank_lines_spec.rb
+++ b/spec/functions/remove_blank_lines_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+input = <<-TEXT
+  string_name: "string_value"
+
+  int_name: 42
+
+  true_name: yes
+TEXT
+output = <<-TEXT.chomp
+  string_name: "string_value"
+  int_name: 42
+  true_name: yes
+TEXT
+
+describe 'extlib::remove_blank_lines' do
+  it { is_expected.to run.with_params(input).and_return(output) }
+end


### PR DESCRIPTION
This functions removes all blan lines from a block of text e.g

input = ```
foo

bar

foobar
```

output=```
foo
bar
foobar
```

edit: renamed from `clean_blank_lines` to `remove_blank_lines` but open to better names