### PR TITLE
Add `confdir` to extlib__puppet_config

### DIFF
--- a/lib/facter/extlib__puppet_config.rb
+++ b/lib/facter/extlib__puppet_config.rb
@@ -2,7 +2,9 @@
 
 Facter.add(:extlib__puppet_config) do
   setcode do
-    puppet_config = {}
+    puppet_config = {
+      'confdir' => Puppet.settings['confdir'],
+    }
 
     desired_settings = {
       master: %i[

--- a/spec/unit/facter/extlib__puppet_config_spec.rb
+++ b/spec/unit/facter/extlib__puppet_config_spec.rb
@@ -23,7 +23,8 @@ describe 'extlib__puppet_config fact' do
       },
       'agent' => {
         'environment' => 'production'
-      }
+      },
+      'confdir' => '/dev/null'
     }
   end
 


### PR DESCRIPTION
#### Pull Request (PR) description
Add the puppet config directory to the fact.  This will allow folks to more easily find the puppet config directory for adding/tweaking/etc elements along side the puppet configuration.

#### This Pull Request (PR) fixes the following issues

