### PR TITLE
Fix `remove_resource` `Attempt to redefine entity`

### DIFF
--- a/lib/puppet/functions/extlib/remove_resource.rb
+++ b/lib/puppet/functions/extlib/remove_resource.rb
@@ -40,7 +40,8 @@ Puppet::Functions.create_function(:'extlib::remove_resource', Puppet::Functions:
   end
 
   def remove_resource(scope, resource, soft_fail = nil)
-    catalog_resource = scope.catalog.resource(resource.type_name, resource.title)
+    type = Puppet::Pops::Evaluator::Runtime3ResourceSupport.find_resource_type(scope, resource.type_name)
+    catalog_resource = scope.compiler.findresource(type, resource.title)
 
     if catalog_resource
       # To remove the resource, we reverse the actions from compiler.add_resource


### PR DESCRIPTION
The previous implementation used to find the resource in the catalog was causing the following style of error on the Puppetserver.

```
Server Error: Evaluation Error: Error while evaluating a Function Call, Could not autoload puppet/type/file_line: Attempt to redefine entity 'http://puppet.com/2016.1/runtime/type/file_line'
```

This only occurred the first time trying to compile the catalog. Subsequent runs against the same puppetserver would work fine.  I don't fully understand what was causing the type to be reloaded, and this was only an issue if `generate types` had been used to create the `.resource_types/*.pp` metadata file for the type. Presumably puppet is upset when it tries to load the ruby definition of a type after it's already loaded the pcore version??

In this commit, we switch to the same mechanism used by the `defined` function.
