### PR TITLE
Add functions for retrieving latest versions from various services

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -36,6 +36,9 @@ Thus making it directly usable with the values from facter.
 * [`extlib::to_ini`](#extlib--to_ini): This converts a puppet hash to an INI string.
 
 Based on https://github.com/mmckinst/puppet-hash2stuff/blob/master/lib/puppet/parser/functions/hash2ini.rb
+* [`extlib::version_latest_anitya`](#extlib--version_latest_anitya): Retrieves the latest version for a project on Anitya / release-monitoring.org
+* [`extlib::version_latest_endoflife`](#extlib--version_latest_endoflife): Retrieves the latest release name for a product tracked on endoflife.date
+* [`extlib::version_latest_github`](#extlib--version_latest_github): Retrieves the latest release tag for a GitHub project
 
 ## Functions
 
@@ -1356,4 +1359,166 @@ Data structure which needs to be converted into ini
 Data type: `Optional[Hash]`
 
 Override default ini generation settings
+
+### <a name="extlib--version_latest_anitya"></a>`extlib::version_latest_anitya`
+
+Type: Ruby 4.x API
+
+Retrieves the latest version for a project on Anitya / release-monitoring.org
+
+#### `extlib::version_latest_anitya(Integer[1] $project)`
+
+The extlib::version_latest_anitya function.
+
+Returns: `String` The latest version for the project
+
+##### Examples
+
+###### Get latest version
+
+```puppet
+extlib::version_latest_anitya(4223) # Project 4223 is Ruby
+# => 3.4.6
+```
+
+##### `project`
+
+Data type: `Integer[1]`
+
+The Anitya project to check for releases
+
+#### `extlib::version_latest_anitya(Integer[1] $project, SemVerRange $range)`
+
+The extlib::version_latest_anitya function.
+
+Returns: `String` The latest tag matching the provided range
+
+##### Examples
+
+###### Get latest version for a specified range
+
+```puppet
+extlib::version_latest_anitya(4223, '~3.3') # Project 4223 is Ruby
+# => 3.3.9
+```
+
+##### `project`
+
+Data type: `Integer[1]`
+
+The Anitya project to check for releases
+
+##### `range`
+
+Data type: `SemVerRange`
+
+The range of acceptable versions
+
+### <a name="extlib--version_latest_endoflife"></a>`extlib::version_latest_endoflife`
+
+Type: Ruby 4.x API
+
+Retrieves the latest release name for a product tracked on endoflife.date
+
+#### `extlib::version_latest_endoflife(String[1] $product)`
+
+The extlib::version_latest_endoflife function.
+
+Returns: `String` The latest version for the product
+
+##### Examples
+
+###### Get latest version
+
+```puppet
+extlib::version_latest_endoflife('ubuntu')
+# => 25.04
+```
+
+##### `product`
+
+Data type: `String[1]`
+
+The endoflife.date product to check for releases
+
+#### `extlib::version_latest_endoflife(String[1] $product, String[1] $cycle)`
+
+The extlib::version_latest_endoflife function.
+
+Returns: `String` The latest version for the product in the provided cycle
+
+##### Examples
+
+###### Get latest version for specified cycle
+
+```puppet
+extlib::version_latest_endoflife('ubuntu', '24.04')
+# => 24.04.3
+```
+
+##### `product`
+
+Data type: `String[1]`
+
+The endoflife.date product to check for releases
+
+##### `cycle`
+
+Data type: `String[1]`
+
+The release cycle to check
+
+### <a name="extlib--version_latest_github"></a>`extlib::version_latest_github`
+
+Type: Ruby 4.x API
+
+Retrieves the latest release tag for a GitHub project
+
+#### `extlib::version_latest_github(String[1] $project)`
+
+The extlib::version_latest_github function.
+
+Returns: `String` The latest tag for the project
+
+##### Examples
+
+###### Get latest version
+
+```puppet
+extlib::version_latest_github('OpenVoxProject/openvox')
+# => 8.23.1
+```
+
+##### `project`
+
+Data type: `String[1]`
+
+The GitHub project to check for releases
+
+#### `extlib::version_latest_github(String[1] $project, SemVerRange $range)`
+
+The extlib::version_latest_github function.
+
+Returns: `String` The latest tag matching the provided range
+
+##### Examples
+
+###### Get latest version for specified range
+
+```puppet
+extlib::version_latest_github('OpenVoxProject/openvox', '~7')
+# => 7.37.2
+```
+
+##### `project`
+
+Data type: `String[1]`
+
+The GitHub project to check for releases
+
+##### `range`
+
+Data type: `SemVerRange`
+
+The range of acceptable versions
 

--- a/lib/puppet/functions/extlib/version_latest_anitya.rb
+++ b/lib/puppet/functions/extlib/version_latest_anitya.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require_relative '../../../puppet_x/simple_cache'
+
+# @summary Retrieves the latest version for a project on Anitya / release-monitoring.org
+Puppet::Functions.create_function(:'extlib::version_latest_anitya') do
+  # @example Get latest version
+  #     extlib::version_latest_anitya(4223) # Project 4223 is Ruby
+  #     # => 3.4.6
+  #
+  # @param project The Anitya project to check for releases
+  #
+  # @return [String] The latest version for the project
+  dispatch :get_latest do
+    param 'Integer[1]', :project
+    return_type 'String'
+  end
+
+  # @example Get latest version for a specified range
+  #     extlib::version_latest_anitya(4223, '~3.3') # Project 4223 is Ruby
+  #     # => 3.3.9
+  #
+  # @param project The Anitya project to check for releases
+  # @param range The range of acceptable versions
+  #
+  # @todo Allow retrieving pre-release versions
+  #
+  # @return [String] The latest tag matching the provided range
+  dispatch :get_latest_semver do
+    param 'Integer[1]', :project
+    param 'SemVerRange', :range
+    return_type 'String'
+  end
+
+  require 'json'
+  require 'net/http'
+  require 'uri'
+
+  def base_url
+    'https://release-monitoring.org/api/v2/'
+  end
+
+  def get_latest(project)
+    get_anitya(project)['latest_version']
+  end
+
+  def get_latest_semver(project, range)
+    found = get_anitya(project)['stable_versions'].find do |version|
+      version = version[1..] if version[0].downcase == 'v'
+      if version.count('.') < 2
+        # Handle semver-like version numbers (e.g. Version 2, Version 1.5, Version 0.4)
+        parts = version.split '.'
+        parts.map! { |part| part =~ %r{^\d+$} ? part.to_i : part }
+        parts << 0 until parts.size >= 3
+        version = parts.join '.'
+      end
+
+      version = SemanticPuppet::Version.parse(version)
+      range.include? version
+    rescue SemanticPuppet::Version::ValidationFailure
+      # Invalid version number in list, continue
+    end
+
+    raise "No stable versions found that matches #{range}" unless found
+
+    found
+  end
+
+  private
+
+  def get_anitya(project)
+    PuppetX::SimpleCache.cache_data("anitya_#{project}") do
+      url = URI([base_url, 'versions/?project_id=', project].join)
+      resp = Net::HTTP.get_response(url)
+      resp.value
+      JSON.parse(resp.body)
+    end
+  end
+end

--- a/lib/puppet/functions/extlib/version_latest_endoflife.rb
+++ b/lib/puppet/functions/extlib/version_latest_endoflife.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative '../../../puppet_x/simple_cache'
+
+# @summary Retrieves the latest release name for a product tracked on endoflife.date
+Puppet::Functions.create_function(:'extlib::version_latest_endoflife') do
+  # @example Get latest version
+  #     extlib::version_latest_endoflife('ubuntu')
+  #     # => 25.04
+  #
+  # @param product The endoflife.date product to check for releases
+  #
+  # @return [String] The latest version for the product
+  dispatch :get_latest do
+    param 'String[1]', :product
+    return_type 'String'
+  end
+
+  # @example Get latest version for specified cycle
+  #     extlib::version_latest_endoflife('ubuntu', '24.04')
+  #     # => 24.04.3
+  #
+  # @param product The endoflife.date product to check for releases
+  # @param cycle The release cycle to check
+  #
+  # @return [String] The latest version for the product in the provided cycle
+  dispatch :get_latest_cycle do
+    param 'String[1]', :product
+    param 'String[1]', :cycle
+    return_type 'String'
+  end
+
+  require 'json'
+  require 'net/http'
+  require 'uri'
+
+  def base_url
+    'https://endoflife.date/api/v1'
+  end
+
+  def get_latest(product)
+    get_latest_cycle(product, :latest)
+  end
+
+  def get_latest_cycle(product, cycle)
+    data = get_eol(product, cycle)
+
+    # For nicer output
+    cycle = cycle == :latest ? nil : " #{cycle}"
+    if data['isEol']
+      since = " since #{data['eolFrom']}" if data['eolFrom']
+      Puppet.warning "Latest version for #{product}#{cycle} is end-of-life#{since}"
+    elsif data['isDiscontinued']
+      since = " since #{data['discontinuedFrom']}" if data['discontinuedFrom']
+      Puppet.warning "Latest version for #{product}#{cycle} is discontinued#{since}"
+    end
+
+    data.dig('latest', 'name')
+  end
+
+  private
+
+  def get_eol(product, cycle)
+    PuppetX::SimpleCache.cache_data("eol_#{product}_#{cycle}") do |meta|
+      url = URI([base_url, :products, product, :releases, cycle].join('/'))
+      hdr = {}
+      hdr['if-none-match'] = meta['etag'] if meta['etag']
+      resp = Net::HTTP.get_response(url, hdr)
+      if resp.is_a? Net::HTTPNotModified
+        meta['keep'] = true
+      else
+        resp.value
+        meta['etag'] = resp['etag']
+        JSON.parse(resp.body)
+      end
+    end['result']
+  end
+end

--- a/lib/puppet/functions/extlib/version_latest_github.rb
+++ b/lib/puppet/functions/extlib/version_latest_github.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require_relative '../../../puppet_x/simple_cache'
+
+# @summary Retrieves the latest release tag for a GitHub project
+Puppet::Functions.create_function(:'extlib::version_latest_github') do
+  # @example Get latest version
+  #     extlib::version_latest_github('OpenVoxProject/openvox')
+  #     # => 8.23.1
+  #
+  # @param project The GitHub project to check for releases
+  #
+  # @return [String] The latest tag for the project
+  dispatch :get_latest do
+    param 'String[1]', :project
+    return_type 'String'
+  end
+
+  # @example Get latest version for specified range
+  #     extlib::version_latest_github('OpenVoxProject/openvox', '~7')
+  #     # => 7.37.2
+  #
+  # @param project The GitHub project to check for releases
+  # @param range The range of acceptable versions
+  #
+  # @return [String] The latest tag matching the provided range
+  dispatch :get_latest_semver do
+    param 'String[1]', :project
+    param 'SemVerRange', :range
+    return_type 'String'
+  end
+
+  require 'json'
+  require 'net/http'
+  require 'uri'
+
+  def base_url
+    'https://api.github.com/repos/%s/releases'
+  end
+
+  def get_latest(project)
+    get_github(project, :latest)['tag_name']
+  end
+
+  def get_latest_semver(project, range)
+    found = get_github(project).map { |rel| rel['tag_name'] }.find do |version|
+      version = version[1..] if version[0].downcase == 'v'
+      if version.count('.') < 2
+        # Handle semver-like version numbers (e.g. Version 2, Version 1.5, Version 0.4)
+        parts = version.split '.'
+        parts.map! { |part| part =~ %r{^\d+$} ? part.to_i : part }
+        parts << 0 until parts.size >= 3
+        version = parts.join '.'
+      end
+
+      version = SemanticPuppet::Version.parse(version)
+      range.include? version
+    rescue SemanticPuppet::Version::ValidationFailure
+      # Invalid version number in list, continue
+    end
+
+    raise "No stable versions found that matches #{range}" unless found
+
+    found
+  end
+
+  private
+
+  def project_slug(project)
+    project.tr '/', '_'
+  end
+
+  def get_github(project, suffix = nil)
+    cache_tag = "gh_#{project_slug(project)}"
+    cache_tag += "_#{suffix}" if suffix
+    PuppetX::SimpleCache.cache_data(cache_tag) do |meta|
+      url = URI([base_url % project, suffix].compact.join('/'))
+      hdr = {}
+      hdr['if-none-match'] = meta['etag'] if meta['etag']
+      resp = Net::HTTP.get_response(url, hdr)
+      if resp.is_a? Net::HTTPNotModified
+        meta['keep'] = true
+      else
+        resp.value
+        meta['etag'] = resp['etag']
+        JSON.parse(resp.body)
+      end
+    end
+  end
+end

--- a/lib/puppet_x/simple_cache.rb
+++ b/lib/puppet_x/simple_cache.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module PuppetX
+  # @summary A simple cache for storing data retrieved from external systems
+  module SimpleCache
+    # Be a good internet citizen, perform a maximum of 10 queries per day
+    DURATION = 2.5 * 60 * 60
+
+    def self.default_cache_path
+      File.join(Puppet[:vardir] || '/tmp/puppet', 'simple-cache')
+    end
+
+    # @param identifier The cache identifier
+    # @param duration How long the cached data should be considered valid - also accepts :forever
+    # @param cache_path A custom path to store the cache under
+    # @param _block The block to execute in order to retrieve the data requiring caching
+    def self.cache_data(identifier, duration: DURATION, cache_path: nil, &_block)
+      uid = File.stat(Puppet[:vardir]).uid if Dir.exist?(Puppet[:vardir])
+      cache_path ||= default_cache_path
+
+      file = File.join(cache_path, identifier)
+      if File.exist?(file)
+        begin
+          file_data = YAML.safe_load(File.read(file))
+          meta = file_data['meta'] || {}
+          return file_data['data'] if file_data['data'] && (duration == :forever || Time.at(file_data['at']) + duration > Time.now)
+        rescue StandardError # Cache corruption failsafe
+          file_data = nil
+          meta = {}
+        end
+      end
+
+      meta ||= {}
+      data = yield meta
+      data = file_data['data'] if meta.delete('keep') # Never store the keep flag
+
+      raise 'No data to cache' unless data
+
+      FileUtils.mkdir_p(cache_path)
+      File.open(file, 'w', 0o600) do |c|
+        c.write({ 'data' => data, 'meta' => meta, 'at' => Time.now.to_i }.to_yaml)
+      end
+      File.chown(uid, nil, file) if uid
+      File.chown(uid, nil, cache_path) if uid
+
+      data
+    end
+  end
+end

--- a/spec/functions/extlib/version_latest_anitya_spec.rb
+++ b/spec/functions/extlib/version_latest_anitya_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'extlib::version_latest_anitya' do
+  let(:anitya_project) { 4223 }
+  let(:anitya_output) do
+    {
+      latest_version: '3.4.6',
+      stable_versions: [
+        '3.4.6', '3.4.5', '3.4.4', '3.4.3', '3.4.2', '3.4.1', '3.4.0', '3.3.9', '3.3.8', '3.3.7', '3.3.6', '3.3.5', '3.3.4', '3.3.3', '3.3.2', '3.3.1', '3.3.0', '3.2.9', '3.2.8', '3.2.7'
+      ],
+      versions: [
+        '3.4.6', '3.4.5', '3.4.4', '3.4.3', '3.4.2', '3.4.1', '3.4.0', '3.3.9', '3.3.8', '3.3.7', '3.3.6', '3.3.5', '3.3.4', '3.3.3', '3.3.2', '3.3.1', '3.3.0', '3.3.0-rc1', '3.3.0-preview3', '3.3.0-preview2'
+      ]
+    }
+  end
+
+  before do
+    response_double = instance_double(Net::HTTPResponse)
+    allow(Net::HTTP).to receive(:get_response).with(URI('https://release-monitoring.org/api/v2/versions/?project_id=4223')).and_return(response_double)
+    allow(response_double).to receive(:value)
+    allow(response_double).to receive(:body).and_return(anitya_output.to_json)
+
+    # Disable writing the cache files
+    allow(FileUtils).to receive(:mkdir_p)
+    allow(File).to receive(:open)
+    allow(File).to receive(:chown)
+  end
+
+  context 'for ruby latest' do
+    it { is_expected.to run.with_params(anitya_project).and_return('3.4.6') }
+  end
+
+  context 'for ruby 3' do
+    let(:anitya_range) { SemanticPuppet::VersionRange.parse('~3') }
+
+    it { is_expected.to run.with_params(anitya_project, anitya_range).and_return('3.4.6') }
+  end
+
+  context 'for ruby 3.2' do
+    let(:anitya_range) { SemanticPuppet::VersionRange.parse('~3.2') }
+
+    it { is_expected.to run.with_params(anitya_project, anitya_range).and_return('3.2.9') }
+  end
+
+  context 'for non-existant ruby 42.0' do
+    let(:anitya_range) { SemanticPuppet::VersionRange.parse('~42.0') }
+
+    it { is_expected.to run.with_params(anitya_project, anitya_range).and_raise_error(RuntimeError, 'No stable versions found that matches ~42.0') }
+  end
+end

--- a/spec/functions/extlib/version_latest_endoflife_spec.rb
+++ b/spec/functions/extlib/version_latest_endoflife_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'extlib::version_latest_endoflife' do
+  let(:endoflife_product) { 'kubernetes' }
+  let(:endoflife_cycle) { 'latest' }
+  let(:endoflife_output) do
+    {
+      schema_version: '1.2.0',
+      generated_at: '2025-10-06T00:36:52+00:00',
+      result: {
+        name: '1.34',
+        codename: nil,
+        label: '1.34',
+        releaseDate: '2025-08-27',
+        isLts: false,
+        ltsFrom: nil,
+        isEoas: false,
+        eoasFrom: nil,
+        isEol: false,
+        eolFrom: nil,
+        isMaintained: true,
+        latest: {
+          name: '1.34.1',
+          date: '2025-09-09',
+          link: 'https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.34.md'
+        },
+        custom: nil
+      }
+    }
+  end
+
+  before do
+    response_double = instance_double(Net::HTTPResponse)
+    allow(Net::HTTP).to receive(:get_response).with(URI("https://endoflife.date/api/v1/products/#{endoflife_product}/releases/#{endoflife_cycle}"), {}).and_return(response_double)
+    allow(response_double).to receive(:value)
+    allow(response_double).to receive(:[]).with('etag')
+    allow(response_double).to receive(:body).and_return(endoflife_output.to_json)
+
+    # Disable writing the cache files
+    allow(FileUtils).to receive(:mkdir_p)
+    allow(File).to receive(:open)
+    allow(File).to receive(:chown)
+  end
+
+  context 'for latest Kubernetes' do
+    it { is_expected.to run.with_params(endoflife_product).and_return('1.34.1') }
+  end
+
+  context 'for end-of-life Kubernetes 1.30' do
+    let(:endoflife_cycle) { '1.30' }
+    let(:endoflife_output) do
+      {
+        schema_version: '1.2.0',
+        generated_at: '2025-10-06T00:36:52+00:00',
+        result: {
+          name: '1.30',
+          codename: nil,
+          label: '1.30',
+          releaseDate: '2024-04-17',
+          isLts: false,
+          ltsFrom: nil,
+          isEoas: true,
+          eoasFrom: '2025-04-28',
+          isEol: true,
+          eolFrom: '2025-06-28',
+          isMaintained: false,
+          latest: {
+            name: '1.30.14',
+            date: '2025-06-17',
+            link: 'https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md'
+          },
+          custom: nil
+        }
+      }
+    end
+
+    it do
+      allow(Puppet).to receive(:warning).with('Latest version for kubernetes 1.30 is end-of-life since 2025-06-28')
+      is_expected.to run.with_params(endoflife_product, endoflife_cycle).and_return('1.30.14')
+      expect(Puppet).to have_received(:warning)
+    end
+  end
+end

--- a/spec/functions/extlib/version_latest_github_spec.rb
+++ b/spec/functions/extlib/version_latest_github_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'extlib::version_latest_github' do
+  let(:github_project) { 'OpenVoxProject/openvox' }
+  let(:github_output) do
+    [
+      # Trimmed to minimal size, for testing purposes
+      { tag_name: '8.23.1' },
+      { tag_name: '8.23.0' },
+      { tag_name: '8.22.0' },
+      { tag_name: '8.21.1' },
+      { tag_name: '8.21.0' },
+      { tag_name: '8.20.0' },
+      { tag_name: '8.19.2' },
+      { tag_name: '7.37.2' },
+      { tag_name: '8.19.1' },
+      { tag_name: '7.37.1' },
+      { tag_name: '7.37.0' },
+      { tag_name: '8.19.0' }
+    ]
+  end
+
+  before do
+    response_double = instance_double(Net::HTTPResponse)
+    allow(Net::HTTP).to receive(:get_response).with(URI("https://api.github.com/repos/#{github_project}/releases"), {}).and_return(response_double)
+    allow(response_double).to receive(:value)
+    allow(response_double).to receive(:[]).with('etag')
+    allow(response_double).to receive(:body).and_return(github_output.to_json)
+
+    # Disable writing the cache files
+    allow(FileUtils).to receive(:mkdir_p)
+    allow(File).to receive(:open)
+    allow(File).to receive(:chown)
+  end
+
+  context 'for openvox latest' do
+    before do
+      response_double = instance_double(Net::HTTPResponse)
+      allow(Net::HTTP).to receive(:get_response).with(URI("https://api.github.com/repos/#{github_project}/releases/latest"), {}).and_return(response_double)
+      allow(response_double).to receive(:value)
+      allow(response_double).to receive(:[]).with('etag')
+      allow(response_double).to receive(:body).and_return(github_output.first.to_json)
+    end
+
+    it { is_expected.to run.with_params(github_project).and_return('8.23.1') }
+  end
+
+  context 'for openvox 8.19' do
+    let(:github_range) { SemanticPuppet::VersionRange.parse('~8.19') }
+
+    it { is_expected.to run.with_params(github_project, github_range).and_return('8.19.2') }
+  end
+
+  context 'for openvox 7' do
+    let(:github_range) { SemanticPuppet::VersionRange.parse('~7') }
+
+    it { is_expected.to run.with_params(github_project, github_range).and_return('7.37.2') }
+  end
+
+  context 'for non-existant openvox 42.0' do
+    let(:github_range) { SemanticPuppet::VersionRange.parse('~42.0') }
+
+    it { is_expected.to run.with_params(github_project, github_range).and_raise_error(RuntimeError, 'No stable versions found that matches ~42.0') }
+  end
+end

--- a/spec/unit/puppet_x/simple_cache_spec.rb
+++ b/spec/unit/puppet_x/simple_cache_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'puppet_x/simple_cache'
+
+describe PuppetX::SimpleCache do
+  let(:cache_identifier) { 'testing' }
+  let(:cache_data) { 'Data to cache' }
+
+  around do |example|
+    Dir.mktmpdir('rspec-') do |dir|
+      @temp_dir = dir
+      example.run
+    end
+  end
+
+  attr_reader :temp_dir
+
+  describe 'with defaults' do
+    it do
+      expect(described_class.cache_data(cache_identifier, cache_path: temp_dir) { cache_data }).to eq(cache_data)
+      expect(described_class.cache_data(cache_identifier, cache_path: temp_dir) { 'another value' }).to eq(cache_data)
+    end
+  end
+
+  describe 'after cache time-out' do
+    it do
+      expect(described_class.cache_data(cache_identifier, cache_path: temp_dir) { cache_data }).to eq(cache_data)
+      expect(described_class.cache_data(cache_identifier, duration: 10, cache_path: temp_dir) { 'another value' }).to eq(cache_data)
+
+      expect(described_class.cache_data(cache_identifier, duration: -1, cache_path: temp_dir) { 'another value' }).not_to eq(cache_data)
+    end
+  end
+
+  describe 'metadata handling' do
+    it do
+      expect(described_class.cache_data(cache_identifier, cache_path: temp_dir) do |meta|
+        meta['key'] = 'value'
+        cache_data
+      end).to eq(cache_data)
+
+      # Expect metadata to be passed along
+      extracted_meta = nil
+      expect(described_class.cache_data(cache_identifier, duration: -1, cache_path: temp_dir) do |meta|
+        extracted_meta = meta['key']
+        cache_data
+      end).to eq(cache_data)
+      expect(extracted_meta).to eq('value')
+    end
+
+    it do
+      expect(described_class.cache_data(cache_identifier, cache_path: temp_dir) { cache_data }).to eq(cache_data)
+      expect(described_class.cache_data(cache_identifier, cache_path: temp_dir) do |meta|
+        meta['keep'] = true
+        'another value'
+      end).to eq(cache_data)
+
+      # Allow keeping outdated cache values, for use with etag/304 and similar
+      expect(described_class.cache_data(cache_identifier, duration: -1, cache_path: temp_dir) do |meta|
+        meta['keep'] = true
+        'another value'
+      end).to eq(cache_data)
+    end
+  end
+end


### PR DESCRIPTION
These are being upstreamed from code that's running internally at Linköping University, in cases like these; (with our internal identifiers replaced with these extlib names)
```puppet
# class profiles::kube::node(
#   $release => 1.33
#   $etcd_release => 3.5

class { 'k8s':
  version      => extlib::version_latest_endoflife('kubernetes', $release),
  etcd_version => extlib::version_latest_endoflife('etcd', $etcd_release),
# ...
}
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Adds functions for querying various services to retrieve the latest versions of projects/products.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
