### PR TITLE
Add get_ip_in_cidr function, extracted from puppet-k8s

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -17,6 +17,7 @@
 * [`extlib::dump_params`](#extlib--dump_params): this function is used to get a list of parameters passed to or resource.
 * [`extlib::echo`](#extlib--echo): This function outputs the variable content and its type to the debug log. It's similiar to the `notice` function but provides a better output
 * [`extlib::file_separator`](#extlib--file_separator): Returns the os specific file path separator.
+* [`extlib::get_ip_in_cidr`](#extlib--get_ip_in_cidr): Retrieves an IP inside of a CIDR based on an index
 * [`extlib::has_module`](#extlib--has_module): A function that lets you know whether a specific module is on your modulepath.
 * [`extlib::ip_to_cron`](#extlib--ip_to_cron): Provides a "random" value to cron based on the last bit of the machine IP address. used to avoid starting a certain cron job at the same time
 * [`extlib::ip_to_reverse`](#extlib--ip_to_reverse): Returns the reverse of an IP address
@@ -568,6 +569,60 @@ Returns: `String` - The os specific path separator.
 ```puppet
 extlib::file_separator() => '/'
 ```
+
+### <a name="extlib--get_ip_in_cidr"></a>`extlib::get_ip_in_cidr`
+
+Type: Ruby 4.x API
+
+Retrieves an IP inside of a CIDR based on an index
+
+#### Examples
+
+##### In 192.168.0.0/24
+
+```puppet
+extlib::get_ip_in_cidr('192.168.0.0/24', 'first')
+# => 192.168.0.1
+extlib::get_ip_in_cidr('192.168.0.0/24', 'second')
+# => 192.168.0.2
+extlib::get_ip_in_cidr('192.168.0.0/16', 600)
+# => 192.168.1.244
+extlib::get_ip_in_cidr('192.168.0.0/16', -2)
+# => 192.168.255.254
+```
+
+#### `extlib::get_ip_in_cidr(Variant[Stdlib::IP::Address::V4::CIDR, Stdlib::IP::Address::V6::CIDR] $cidr, Optional[Variant[Enum["first","second","last"], Integer]] $index)`
+
+The extlib::get_ip_in_cidr function.
+
+Returns: `String` The requested IP address index in the CIDR
+
+##### Examples
+
+###### In 192.168.0.0/24
+
+```puppet
+extlib::get_ip_in_cidr('192.168.0.0/24', 'first')
+# => 192.168.0.1
+extlib::get_ip_in_cidr('192.168.0.0/24', 'second')
+# => 192.168.0.2
+extlib::get_ip_in_cidr('192.168.0.0/16', 600)
+# => 192.168.1.244
+extlib::get_ip_in_cidr('192.168.0.0/16', -2)
+# => 192.168.255.254
+```
+
+##### `cidr`
+
+Data type: `Variant[Stdlib::IP::Address::V4::CIDR, Stdlib::IP::Address::V6::CIDR]`
+
+The CIDR to work on
+
+##### `index`
+
+Data type: `Optional[Variant[Enum["first","second","last"], Integer]]`
+
+The index of the IP to retrieve, retrieving from the end if negative
 
 ### <a name="extlib--has_module"></a>`extlib::has_module`
 

--- a/lib/puppet/functions/extlib/get_ip_in_cidr.rb
+++ b/lib/puppet/functions/extlib/get_ip_in_cidr.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# @summary Retrieves an IP inside of a CIDR based on an index
+Puppet::Functions.create_function(:'extlib::get_ip_in_cidr') do
+  # @example In 192.168.0.0/24
+  #     extlib::get_ip_in_cidr('192.168.0.0/24', 'first')
+  #     # => 192.168.0.1
+  #     extlib::get_ip_in_cidr('192.168.0.0/24', 'second')
+  #     # => 192.168.0.2
+  #     extlib::get_ip_in_cidr('192.168.0.0/16', 600)
+  #     # => 192.168.1.244
+  #     extlib::get_ip_in_cidr('192.168.0.0/16', -2)
+  #     # => 192.168.255.254
+  #
+  # @param cidr The CIDR to work on
+  # @param index The index of the IP to retrieve, retrieving from the end if negative
+  #
+  # @return [String] The requested IP address index in the CIDR
+  dispatch :get_ip_in_cidr do
+    param 'Variant[Stdlib::IP::Address::V4::CIDR, Stdlib::IP::Address::V6::CIDR]', :cidr
+    optional_param 'Variant[Enum["first","second","last"], Integer]', :index
+    return_type 'String'
+  end
+
+  require 'ipaddr'
+  def get_ip_in_cidr(cidr, index = 1)
+    cidr = cidr.first if cidr.is_a? Array
+
+    if index.is_a? String
+      index = 1 if index == 'first'
+      index = 2 if index == 'second'
+      index = -1 if index == 'last'
+    end
+
+    ip = IPAddr.new(cidr)
+
+    max_width = ip.ipv4? ? 32 : 128
+    max_num = 2**(max_width - ip.prefix)
+
+    index = max_num + index if index.negative?
+    raise ArgumentError, 'Index is outside of the CIDR' if index >= max_num
+
+    IPAddr.new(ip.to_i + index, ip.family).to_s
+  end
+end

--- a/lib/puppet/functions/extlib/get_ip_in_cidr.rb
+++ b/lib/puppet/functions/extlib/get_ip_in_cidr.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ipaddr'
+
 # @summary Retrieves an IP inside of a CIDR based on an index
 Puppet::Functions.create_function(:'extlib::get_ip_in_cidr') do
   # @example In 192.168.0.0/24
@@ -22,14 +24,18 @@ Puppet::Functions.create_function(:'extlib::get_ip_in_cidr') do
     return_type 'String'
   end
 
-  require 'ipaddr'
   def get_ip_in_cidr(cidr, index = 1)
-    cidr = cidr.first if cidr.is_a? Array
-
     if index.is_a? String
-      index = 1 if index == 'first'
-      index = 2 if index == 'second'
-      index = -1 if index == 'last'
+      index = case index
+              when 'first'
+                1
+              when 'second'
+                2
+              when 'last'
+                -1
+              else
+                raise ArgumentError, 'Invalid index'
+              end
     end
 
     ip = IPAddr.new(cidr)

--- a/spec/functions/extlib/get_ip_in_cidr_spec.rb
+++ b/spec/functions/extlib/get_ip_in_cidr_spec.rb
@@ -7,6 +7,7 @@ describe 'extlib::get_ip_in_cidr' do
   it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
   it { is_expected.to run.with_params('one').and_raise_error(ArgumentError) }
   it { is_expected.to run.with_params('192.168.0.0/24', 600).and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('192.168.0.0/24', 'other').and_raise_error(ArgumentError) }
 
   it { is_expected.to run.with_params('172.0.0.0/8').and_return('172.0.0.1') }
   it { is_expected.to run.with_params('172.0.0.0/8', 'first').and_return('172.0.0.1') }

--- a/spec/functions/extlib/get_ip_in_cidr_spec.rb
+++ b/spec/functions/extlib/get_ip_in_cidr_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'extlib::get_ip_in_cidr' do
+  it { is_expected.not_to be_nil }
+  it { is_expected.to run.with_params.and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('one').and_raise_error(ArgumentError) }
+  it { is_expected.to run.with_params('192.168.0.0/24', 600).and_raise_error(ArgumentError) }
+
+  it { is_expected.to run.with_params('172.0.0.0/8').and_return('172.0.0.1') }
+  it { is_expected.to run.with_params('172.0.0.0/8', 'first').and_return('172.0.0.1') }
+  it { is_expected.to run.with_params('172.0.0.0/8', 'second').and_return('172.0.0.2') }
+  it { is_expected.to run.with_params('172.0.0.0/8', 'last').and_return('172.255.255.255') }
+  it { is_expected.to run.with_params('172.0.0.0/8', -1).and_return('172.255.255.255') }
+  it { is_expected.to run.with_params('172.0.0.0/8', 600).and_return('172.0.2.88') }
+  it { is_expected.to run.with_params('fe80:dead:beef::/64').and_return('fe80:dead:beef::1') }
+  it { is_expected.to run.with_params('fe80:dead:beef::/64', 600).and_return('fe80:dead:beef::258') }
+  it { is_expected.to run.with_params('fc00::/7', -42).and_return('fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffd6') }
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Doing a bit of cleanup in regards to functions, and as this is a general IP address calculation function it makes little sense to keep it in k8s.

This method is used in some other local modules for us, and the dependency graph makes more sense if they don't arbitrarily require k8s.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
