### PR TITLE
Add extlib::sort_hash_deep

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -33,6 +33,7 @@ Thus making it directly usable with the values from facter.
 * [`extlib::remove_resource`](#extlib--remove_resource): Removes a Resource or an Array of Resources from the catalog.
 * [`extlib::resources_deep_merge`](#extlib--resources_deep_merge): Deeply merge a "defaults" hash into a "resources" hash like the ones expected by `create_resources()`.
 * [`extlib::sort_by_version`](#extlib--sort_by_version): A function that sorts an array of version numbers.
+* [`extlib::sort_hash_deep`](#extlib--sort_hash_deep): Recursively sorts a hash by keys to ensure deterministic ordering.
 * [`extlib::to_ini`](#extlib--to_ini): This converts a puppet hash to an INI string.
 
 Based on https://github.com/mmckinst/puppet-hash2stuff/blob/master/lib/puppet/parser/functions/hash2ini.rb
@@ -1308,6 +1309,56 @@ extlib::sort_by_version(['10.0.0b12', '10.0.0b3', '10.0.0a2', '9.0.10', '9.0.3']
 Data type: `Array[String]`
 
 An array of version strings you want sorted.
+
+### <a name="extlib--sort_hash_deep"></a>`extlib::sort_hash_deep`
+
+Type: Ruby 4.x API
+
+Recursively sorts a hash by keys to ensure deterministic ordering.
+
+#### Examples
+
+##### Basic usage
+
+```puppet
+extlib::sort_hash_deep({'b' => 1, 'a' => 2})
+# => {'a' => 2, 'b' => 1}
+```
+
+##### Nested structures
+
+```puppet
+extlib::sort_hash_deep({'z' => {'b' => 2, 'a' => 1}})
+# => {'z' => {'a' => 1, 'b' => 2}}
+```
+
+#### `extlib::sort_hash_deep(Hash $input)`
+
+The extlib::sort_hash_deep function.
+
+Returns: `Hash`
+
+##### Examples
+
+###### Basic usage
+
+```puppet
+extlib::sort_hash_deep({'b' => 1, 'a' => 2})
+# => {'a' => 2, 'b' => 1}
+```
+
+###### Nested structures
+
+```puppet
+extlib::sort_hash_deep({'z' => {'b' => 2, 'a' => 1}})
+# => {'z' => {'a' => 1, 'b' => 2}}
+```
+
+##### `input`
+
+Data type: `Hash`
+
+
 
 ### <a name="extlib--to_ini"></a>`extlib::to_ini`
 

--- a/lib/puppet/functions/extlib/sort_hash_deep.rb
+++ b/lib/puppet/functions/extlib/sort_hash_deep.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# @summary
+#   Recursively sorts a hash by keys to ensure deterministic ordering.
+#
+# @param input [Hash]
+#   The hash to sort. Nested hashes are sorted recursively.
+#
+# @return [Hash]
+#   A new hash with all keys sorted lexicographically at every level.
+#
+# @example Basic usage
+#   extlib::sort_hash_deep({'b' => 1, 'a' => 2})
+#   # => {'a' => 2, 'b' => 1}
+#
+# @example Nested structures
+#   extlib::sort_hash_deep({'z' => {'b' => 2, 'a' => 1}})
+#   # => {'z' => {'a' => 1, 'b' => 2}}
+#
+Puppet::Functions.create_function(:'extlib::sort_hash_deep') do
+  dispatch :sort_hash_deep do
+    param 'Hash', :input
+    return_type 'Hash'
+  end
+
+  def sort_hash_deep(input)
+    input.keys.sort.each_with_object({}) do |k, memo|
+      v = input[k]
+
+      memo[k] =
+        case v
+        when Hash
+          sort_hash_deep(v)
+        when Array
+          v.map do |item|
+            item.is_a?(Hash) ? sort_hash_deep(item) : item
+          end
+        else
+          v
+        end
+    end
+  end
+end

--- a/spec/functions/extlib/sort_hash_deep_spec.rb
+++ b/spec/functions/extlib/sort_hash_deep_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'extlib::sort_hash_deep' do
+  subject(:result) { scope.call_function('extlib::sort_hash_deep', [input]) }
+
+  context 'with a flat hash' do
+    let(:input) do
+      {
+        'b' => 2,
+        'a' => 1,
+        'c' => 3,
+      }
+    end
+
+    it 'sorts keys lexicographically' do
+      expect(result.keys).to eq(%w[a b c])
+    end
+  end
+
+  context 'with nested hashes' do
+    let(:input) do
+      {
+        'z' => {
+          'b' => 2,
+          'a' => 1,
+        },
+        'a' => {
+          'd' => 4,
+          'c' => 3,
+        },
+      }
+    end
+
+    it 'sorts keys at all levels' do
+      expect(result.keys).to eq(%w[a z])
+      expect(result['a'].keys).to eq(%w[c d])
+      expect(result['z'].keys).to eq(%w[a b])
+    end
+  end
+
+  context 'with arrays containing hashes' do
+    let(:input) do
+      {
+        'a' => [
+          { 'b' => 2, 'a' => 1 },
+          { 'd' => 4, 'c' => 3 },
+        ],
+      }
+    end
+
+    it 'sorts hashes inside arrays but preserves array order' do
+      expect(result['a'][0].keys).to eq(%w[a b])
+      expect(result['a'][1].keys).to eq(%w[c d])
+    end
+  end
+
+  context 'idempotency' do
+    let(:input) do
+      {
+        'b' => { 'y' => 2, 'x' => 1 },
+        'a' => 1,
+      }
+    end
+
+    it 'is stable across repeated application' do
+      first  = result
+      second = scope.call_function('extlib::sort_hash_deep', [first])
+
+      expect(second).to eq(first)
+    end
+  end
+
+  context 'with mixed scalar and nested types' do
+    let(:input) do
+      {
+        'b' => true,
+        'd' => [
+          {
+            'f' => [3, 2, 1],
+            'g' => { 'l' => false, 'e' => 321 },
+          },
+        ],
+        'a' => 'string',
+        'c' => 1.23,
+      }
+    end
+
+    it 'preserves values and structure while sorting hashes' do
+      expect(result).to eq(
+        {
+          'a' => 'string',
+          'b' => true,
+          'c' => 1.23,
+          'd' => [
+            {
+              'f' => [3, 2, 1],
+              'g' => {
+                'e' => 321,
+                'l' => false,
+              },
+            },
+          ],
+        },
+      )
+    end
+
+    it 'does not change structure shape' do
+      expect(result).to be_a(Hash)
+      expect(result['d']).to be_a(Array)
+      expect(result['d'][0]).to be_a(Hash)
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds a function that can be used to put a hash into a deterministic order.

When building YAML configs, having a firm, static order prevents configs from being rewritten when the content doesn't actually change.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
